### PR TITLE
Sleep State & Native Death Notices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .vscode/*
 *.code-workspace
+plugins/*

--- a/README.md
+++ b/README.md
@@ -1,72 +1,74 @@
+# SourceCoop
+
 [![CI](https://github.com/ampreeT/SourceCoop/actions/workflows/plugin.yml/badge.svg)](https://github.com/ampreeT/SourceCoop/actions/workflows/plugin.yml)
 [![GitHub Release](https://img.shields.io/github/v/release/ampreeT/SourceCoop?style=flat&label=Release&labelColor=%232C3137&color=%23EB551B)](https://github.com/ampreeT/SourceCoop/releases/latest)
 [![Discord](https://img.shields.io/discord/973591793117564988.svg?label=&logo=discord&logoColor=ffffff&color=7389D8&labelColor=6A7EC2)](https://discord.gg/Fh77rxQaEB)
 
-# SourceCoop
+| [Installation Guide](#installation-guide) - [Campaign Support](#campaign-support) - [Contributing](#contributing) - [Credits](#credits)
+:--: |
+| [Features & Configuration](https://github.com/ampreeT/SourceCoop/wiki/Features-&-Configuration) - [Server Running Tips](https://github.com/ampreeT/SourceCoop/wiki/Server-running-tips) - [Public Servers](https://github.com/ampreeT/SourceCoop/wiki/Public-Servers) |
+|  [Developing](https://github.com/ampreeT/SourceCoop/wiki/Developing) - [EDT Map Script Format](https://github.com/ampreeT/SourceCoop/wiki/EDT---Map-script-format) - [Authoring Maps](https://github.com/ampreeT/SourceCoop/wiki/Authoring-maps-for-SourceCoop) |
 
-SourceCoop is a cooperative mod for multi-player Source Engine games, that
-- Enables players to play together on single-player campaigns or maps
-- Complements existing cooperative campaigns or maps
-- Fixes various crashes
-- Re-enables single-player functionality
-- Includes map configs adjusting for cooperative play
-- Comes with optional addons, enhancing your experience
-- Can be used by server owners as the ultimate map config tool
-- Is built on [SourceMod](https://www.sourcemod.net)
-- __Only needs to be installed on the server__.
+SourceCoop is a cooperative mod for Source Engine games enabling singleplayer campaigns to be played together. It currently supports [Black Mesa](https://store.steampowered.com/app/362890/Black_Mesa/) and [Half-Life 2: Deathmatch](https://store.steampowered.com/app/362890/Black_Mesa/).
+
+- Supports campaigns.
+- Restores singleplayer functionality.
+- Handles world, player and equipment persistence between maps.
+- Easy to use optional addons.
+- Easy to convert maps from singleplayer into cooperative.
 
 ## Installation Guide
-__If you are someone who is looking to play on a server__, you are already completely set up and ready to play! Cooperative servers can be found on the server browser just like any other server.
 
-__If you are a server operator who is looking to host your own cooperative server__, then follow the instructions below.
-- Install [Metamod:Source](https://www.sourcemm.net/downloads.php?branch=stable)
-	- Latest tested build ➤ __1148__
-- Install [SourceMod](https://www.sourcemod.net/downloads.php?branch=stable)
-	- Latest tested build ➤ __6960__
-- Install the latest release of SourceCoop from the [releases page](https://github.com/ampreeT/SourceCoop/releases).
+__If you are someone who is looking to play on a server__, then you are already set up and ready to play! Cooperative servers can be found in the server browser just like any other server.
+
+__If you are a server operator who is looking to host your own cooperative server__, then follow the instructions below:
+
+- Install [Metamod:Source](https://www.sourcemm.net/downloads.php?branch=stable) (latest tested build ➤ __1148__)
+- Install [SourceMod](https://www.sourcemod.net/downloads.php?branch=stable) (latest tested build ➤ __6960__)
+- Install [the latest release of SourceCoop](https://github.com/ampreeT/SourceCoop/releases).
 
 A step-by-step guide for Black Mesa is also available on [Steam](https://steamcommunity.com/sharedfiles/filedetails/?id=2200247356).
 
-## Additional information
-- [Features & Configuration](https://github.com/ampreeT/SourceCoop/wiki/Features-&-Configuration)
-- [Server running tips](https://github.com/ampreeT/SourceCoop/wiki/Server-running-tips)
-- [Authoring maps for SourceCoop](https://github.com/ampreeT/SourceCoop/wiki/Authoring-maps-for-SourceCoop)
-- [EDT Map script format](https://github.com/ampreeT/SourceCoop/wiki/EDT---Map-script-format)
-- [Developing](https://github.com/ampreeT/SourceCoop/wiki/Developing)
-- [Public Servers](https://github.com/ampreeT/SourceCoop/wiki/Public-Servers)
+## Campaign Support
+
+### Black Mesa
+
+- [Main Campaign](https://store.steampowered.com/app/362890/Black_Mesa/)
+- [Stojkeholm](https://steamcommunity.com/sharedfiles/filedetails/?id=2320533262)
+- [Emergency 17](https://steamcommunity.com/sharedfiles/filedetails/?id=934371395)
+
+### Custom Configurations
+
+SourceCoop is __designed to support configurations of singleplayer maps__ without going through the process of decompiling and redistributing map files. Configurations can be created for maps that SourceCoop already does not handle. __If you are interested in creating your own configuration__, read more on [EDT Map Script Format](https://github.com/ampreeT/SourceCoop/wiki/EDT---Map-script-format).
 
 ## Contributing
+
 __If you are looking to help with the development of the project__, we are always looking for more help! Heres some ways you can help:
+
 - Debugging and tracking down issues
 - Adding features
-- Adding configs for new campaigns or levels
+- Adding new configurations for campaigns and maps
 
-If you are interested in helping us, contact us on [Discord](https://discord.gg/Fh77rxQaEB) or create a pull request.
+__If you are interested in helping us__, contact us on [Discord](https://discord.gg/Fh77rxQaEB) or create a pull request.
 
-## Credits
-- __ampreeT__ :: programming, reverse engineering, map editing
-	- [Steam](https://steamcommunity.com/id/ampreeT) | [GitHub](https://github.com/ampreeT)
-- __kasull__ :: programming, reverse engineering, trailer production
-	- [Steam](https://steamcommunity.com/id/kasull/) | [GitHub](https://github.com/kasullian)
-- __Alienmario__ :: programming, reverse engineering, map editing
-	- [Steam](https://steamcommunity.com/id/4oM0/) | [GitHub](https://github.com/Alienmario)
-- __Balimbanana__ :: programming, reverse engineering
-	- [Steam](https://steamcommunity.com/id/Balimbanana/) | [GitHub](https://github.com/Balimbanana)
-- __Rock__ :: programming, map editing
-	- [Steam](https://steamcommunity.com/id/Rock48/) | [GitHub](https://github.com/Rock48)
-- __Krozis Kane__ :: map editing
-	- [Steam](https://steamcommunity.com/id/Krozis_Kane/) | [GitHub](https://github.com/KrozisKane)
-- __ReservedRegister__ :: reverse engineering
-	- [GitHub](https://github.com/ReservedRegister)
+## Dependencies
 
-[__raicovx__](https://github.com/raicovx) :: Equipment persistence
-| [__Jimmy-Baby__](https://github.com/Jimmy-Baby) :: Damage effects addon
-| [__Removiekeen__](https://steamcommunity.com/profiles/76561198804614641/) :: logo design
-| [__yarik2720__](https://github.com/yarik2720) :: CI, Russian translation
+- [SourceMod](https://github.com/alliedmodders/sourcemod)
+- [SourceScramble](https://github.com/nosoop/SMExt-SourceScramble)
+- [stocksoup](https://github.com/nosoop/stocksoup)
+- [sm-logdebug](https://github.com/Alienmario/sm-logdebug)
+- [smlib](https://github.com/bcserv/smlib/tree/transitional_syntax)
 
-#### Third-party libraries
-[SourceMod](https://github.com/alliedmodders/sourcemod)
-| [SourceScramble](https://github.com/nosoop/SMExt-SourceScramble)
-| [stocksoup](https://github.com/nosoop/stocksoup)
-| [sm-logdebug](https://github.com/Alienmario/sm-logdebug)
-| [smlib](https://github.com/bcserv/smlib/tree/transitional_syntax)
+# Credits
+
+- __ampreeT__ :: [Steam](https://steamcommunity.com/id/ampreeT) | [GitHub](https://github.com/ampreeT) :: programming, reverse engineering, map editing
+- __kasull__ :: [Steam](https://steamcommunity.com/id/kasull/) | [GitHub](https://github.com/kasullian) :: programming, reverse engineering, trailer production
+- __Alienmario__ :: [Steam](https://steamcommunity.com/id/4oM0/) | [GitHub](https://github.com/Alienmario) :: programming, reverse engineering, map editing
+- __Balimbanana__ :: [Steam](https://steamcommunity.com/id/Balimbanana/) | [GitHub](https://github.com/Balimbanana) :: programming, reverse engineering
+- __Rock__ :: [Steam](https://steamcommunity.com/id/Rock48/) | [GitHub](https://github.com/Rock48) :: programming, map editing
+- __Krozis Kane__ :: [Steam](https://steamcommunity.com/id/Krozis_Kane/) | [GitHub](https://github.com/KrozisKane) :: map editing
+- __ReservedRegister__ :: [GitHub](https://github.com/ReservedRegister) :: reverse engineering
+- __raicovx__ :: [Github](https://github.com/raicovx) :: Equipment Persistence
+- __Jimmy-Baby__ :: [Github](https://github.com/Jimmy-Baby) :: Damage Effects Addon
+- __Removiekeen__ :: [Steam](https://steamcommunity.com/profiles/76561198804614641/) :: Logo Design
+- __yarik2720__ :: [Github](https://github.com/yarik2720) :: CI, Russian Translation

--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ SourceCoop is a cooperative mod for Source Engine games enabling singleplayer ca
 
 - Supports campaigns.
 - Restores singleplayer functionality.
-- Handles world, player and equipment persistence between maps.
+- Handles player and equipment persistence between maps.
 - Easy to use optional addons.
-- Easy to convert maps from singleplayer into cooperative.
+- Easy for mappers to convert new and existing maps from singleplayer into cooperative.
 
 ## Installation Guide
 
@@ -51,15 +51,10 @@ __If you are looking to help with the development of the project__, we are alway
 
 __If you are interested in helping us__, contact us on [Discord](https://discord.gg/Fh77rxQaEB) or create a pull request.
 
-## Dependencies
 
-- [SourceMod](https://github.com/alliedmodders/sourcemod)
-- [SourceScramble](https://github.com/nosoop/SMExt-SourceScramble)
-- [stocksoup](https://github.com/nosoop/stocksoup)
-- [sm-logdebug](https://github.com/Alienmario/sm-logdebug)
-- [smlib](https://github.com/bcserv/smlib/tree/transitional_syntax)
+## Credits
 
-# Credits
+### Contributors
 
 - __ampreeT__ :: [Steam](https://steamcommunity.com/id/ampreeT) | [GitHub](https://github.com/ampreeT) :: programming, reverse engineering, map editing
 - __kasull__ :: [Steam](https://steamcommunity.com/id/kasull/) | [GitHub](https://github.com/kasullian) :: programming, reverse engineering, trailer production
@@ -68,7 +63,15 @@ __If you are interested in helping us__, contact us on [Discord](https://discord
 - __Rock__ :: [Steam](https://steamcommunity.com/id/Rock48/) | [GitHub](https://github.com/Rock48) :: programming, map editing
 - __Krozis Kane__ :: [Steam](https://steamcommunity.com/id/Krozis_Kane/) | [GitHub](https://github.com/KrozisKane) :: map editing
 - __ReservedRegister__ :: [GitHub](https://github.com/ReservedRegister) :: reverse engineering
-- __raicovx__ :: [Github](https://github.com/raicovx) :: Equipment Persistence
-- __Jimmy-Baby__ :: [Github](https://github.com/Jimmy-Baby) :: Damage Effects Addon
-- __Removiekeen__ :: [Steam](https://steamcommunity.com/profiles/76561198804614641/) :: Logo Design
-- __yarik2720__ :: [Github](https://github.com/yarik2720) :: CI, Russian Translation
+- __raicovx__ :: [Github](https://github.com/raicovx) :: equipment persistence
+- __Jimmy-Baby__ :: [Github](https://github.com/Jimmy-Baby) :: damage effects addon
+- __Removiekeen__ :: [Steam](https://steamcommunity.com/profiles/76561198804614641/) :: logo design
+- __yarik2720__ :: [Github](https://github.com/yarik2720) :: russian translation, ci/cd
+
+### External Libraries
+
+- [SourceMod](https://github.com/alliedmodders/sourcemod)
+- [SourceScramble](https://github.com/nosoop/SMExt-SourceScramble)
+- [stocksoup](https://github.com/nosoop/stocksoup)
+- [sm-logdebug](https://github.com/Alienmario/sm-logdebug)
+- [smlib](https://github.com/bcserv/smlib/tree/transitional_syntax)

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 | [Features & Configuration](https://github.com/ampreeT/SourceCoop/wiki/Features-&-Configuration) - [Server Running Tips](https://github.com/ampreeT/SourceCoop/wiki/Server-running-tips) - [Public Servers](https://github.com/ampreeT/SourceCoop/wiki/Public-Servers) |
 |  [Developing](https://github.com/ampreeT/SourceCoop/wiki/Developing) - [EDT Map Script Format](https://github.com/ampreeT/SourceCoop/wiki/EDT---Map-script-format) - [Authoring Maps](https://github.com/ampreeT/SourceCoop/wiki/Authoring-maps-for-SourceCoop) |
 
-SourceCoop is a cooperative mod for Source Engine games enabling singleplayer campaigns to be played together. It currently supports [Black Mesa](https://store.steampowered.com/app/362890/Black_Mesa/) and [Half-Life 2: Deathmatch](https://store.steampowered.com/app/362890/Black_Mesa/).
+SourceCoop is a cooperative mod for Source Engine games enabling singleplayer campaigns to be played together. It currently supports [Black Mesa](https://store.steampowered.com/app/362890/Black_Mesa/) and [Half-Life 2: Deathmatch](https://store.steampowered.com/app/320/HalfLife_2_Deathmatch/).
 
 - Supports campaigns.
 - Restores singleplayer functionality.

--- a/README.md
+++ b/README.md
@@ -1,77 +1,72 @@
-# SourceCoop
-
 [![CI](https://github.com/ampreeT/SourceCoop/actions/workflows/plugin.yml/badge.svg)](https://github.com/ampreeT/SourceCoop/actions/workflows/plugin.yml)
 [![GitHub Release](https://img.shields.io/github/v/release/ampreeT/SourceCoop?style=flat&label=Release&labelColor=%232C3137&color=%23EB551B)](https://github.com/ampreeT/SourceCoop/releases/latest)
 [![Discord](https://img.shields.io/discord/973591793117564988.svg?label=&logo=discord&logoColor=ffffff&color=7389D8&labelColor=6A7EC2)](https://discord.gg/Fh77rxQaEB)
 
-| [Installation Guide](#installation-guide) - [Campaign Support](#campaign-support) - [Contributing](#contributing) - [Credits](#credits)
-:--: |
-| [Features & Configuration](https://github.com/ampreeT/SourceCoop/wiki/Features-&-Configuration) - [Server Running Tips](https://github.com/ampreeT/SourceCoop/wiki/Server-running-tips) - [Public Servers](https://github.com/ampreeT/SourceCoop/wiki/Public-Servers) |
-|  [Developing](https://github.com/ampreeT/SourceCoop/wiki/Developing) - [EDT Map Script Format](https://github.com/ampreeT/SourceCoop/wiki/EDT---Map-script-format) - [Authoring Maps](https://github.com/ampreeT/SourceCoop/wiki/Authoring-maps-for-SourceCoop) |
+# SourceCoop
 
-SourceCoop is a cooperative mod for Source Engine games enabling singleplayer campaigns to be played together. It currently supports [Black Mesa](https://store.steampowered.com/app/362890/Black_Mesa/) and [Half-Life 2: Deathmatch](https://store.steampowered.com/app/320/HalfLife_2_Deathmatch/).
-
-- Supports campaigns.
-- Restores singleplayer functionality.
-- Handles player and equipment persistence between maps.
-- Easy to use optional addons.
-- Easy for mappers to convert new and existing maps from singleplayer into cooperative.
+SourceCoop is a cooperative mod for multi-player Source Engine games, that
+- Enables players to play together on single-player campaigns or maps
+- Complements existing cooperative campaigns or maps
+- Fixes various crashes
+- Re-enables single-player functionality
+- Includes map configs adjusting for cooperative play
+- Comes with optional addons, enhancing your experience
+- Can be used by server owners as the ultimate map config tool
+- Is built on [SourceMod](https://www.sourcemod.net)
+- __Only needs to be installed on the server__.
 
 ## Installation Guide
+__If you are someone who is looking to play on a server__, you are already completely set up and ready to play! Cooperative servers can be found on the server browser just like any other server.
 
-__If you are someone who is looking to play on a server__, then you are already set up and ready to play! Cooperative servers can be found in the server browser just like any other server.
-
-__If you are a server operator who is looking to host your own cooperative server__, then follow the instructions below:
-
-- Install [Metamod:Source](https://www.sourcemm.net/downloads.php?branch=stable) (latest tested build ➤ __1148__)
-- Install [SourceMod](https://www.sourcemod.net/downloads.php?branch=stable) (latest tested build ➤ __6960__)
-- Install [the latest release of SourceCoop](https://github.com/ampreeT/SourceCoop/releases).
+__If you are a server operator who is looking to host your own cooperative server__, then follow the instructions below.
+- Install [Metamod:Source](https://www.sourcemm.net/downloads.php?branch=stable)
+	- Latest tested build ➤ __1148__
+- Install [SourceMod](https://www.sourcemod.net/downloads.php?branch=stable)
+	- Latest tested build ➤ __6960__
+- Install the latest release of SourceCoop from the [releases page](https://github.com/ampreeT/SourceCoop/releases).
 
 A step-by-step guide for Black Mesa is also available on [Steam](https://steamcommunity.com/sharedfiles/filedetails/?id=2200247356).
 
-## Campaign Support
-
-### Black Mesa
-
-- [Main Campaign](https://store.steampowered.com/app/362890/Black_Mesa/)
-- [Stojkeholm](https://steamcommunity.com/sharedfiles/filedetails/?id=2320533262)
-- [Emergency 17](https://steamcommunity.com/sharedfiles/filedetails/?id=934371395)
-
-### Custom Configurations
-
-SourceCoop is __designed to support configurations of singleplayer maps__ without going through the process of decompiling and redistributing map files. Configurations can be created for maps that SourceCoop already does not handle. __If you are interested in creating your own configuration__, read more on [EDT Map Script Format](https://github.com/ampreeT/SourceCoop/wiki/EDT---Map-script-format).
+## Additional information
+- [Features & Configuration](https://github.com/ampreeT/SourceCoop/wiki/Features-&-Configuration)
+- [Server running tips](https://github.com/ampreeT/SourceCoop/wiki/Server-running-tips)
+- [Authoring maps for SourceCoop](https://github.com/ampreeT/SourceCoop/wiki/Authoring-maps-for-SourceCoop)
+- [EDT Map script format](https://github.com/ampreeT/SourceCoop/wiki/EDT---Map-script-format)
+- [Developing](https://github.com/ampreeT/SourceCoop/wiki/Developing)
+- [Public Servers](https://github.com/ampreeT/SourceCoop/wiki/Public-Servers)
 
 ## Contributing
-
 __If you are looking to help with the development of the project__, we are always looking for more help! Heres some ways you can help:
-
 - Debugging and tracking down issues
 - Adding features
-- Adding new configurations for campaigns and maps
+- Adding configs for new campaigns or levels
 
-__If you are interested in helping us__, contact us on [Discord](https://discord.gg/Fh77rxQaEB) or create a pull request.
-
+If you are interested in helping us, contact us on [Discord](https://discord.gg/Fh77rxQaEB) or create a pull request.
 
 ## Credits
+- __ampreeT__ :: programming, reverse engineering, map editing
+	- [Steam](https://steamcommunity.com/id/ampreeT) | [GitHub](https://github.com/ampreeT)
+- __kasull__ :: programming, reverse engineering, trailer production
+	- [Steam](https://steamcommunity.com/id/kasull/) | [GitHub](https://github.com/kasullian)
+- __Alienmario__ :: programming, reverse engineering, map editing
+	- [Steam](https://steamcommunity.com/id/4oM0/) | [GitHub](https://github.com/Alienmario)
+- __Balimbanana__ :: programming, reverse engineering
+	- [Steam](https://steamcommunity.com/id/Balimbanana/) | [GitHub](https://github.com/Balimbanana)
+- __Rock__ :: programming, map editing
+	- [Steam](https://steamcommunity.com/id/Rock48/) | [GitHub](https://github.com/Rock48)
+- __Krozis Kane__ :: map editing
+	- [Steam](https://steamcommunity.com/id/Krozis_Kane/) | [GitHub](https://github.com/KrozisKane)
+- __ReservedRegister__ :: reverse engineering
+	- [GitHub](https://github.com/ReservedRegister)
 
-### Contributors
+[__raicovx__](https://github.com/raicovx) :: Equipment persistence
+| [__Jimmy-Baby__](https://github.com/Jimmy-Baby) :: Damage effects addon
+| [__Removiekeen__](https://steamcommunity.com/profiles/76561198804614641/) :: logo design
+| [__yarik2720__](https://github.com/yarik2720) :: CI, Russian translation
 
-- __ampreeT__ :: [Steam](https://steamcommunity.com/id/ampreeT) | [GitHub](https://github.com/ampreeT) :: programming, reverse engineering, map editing
-- __kasull__ :: [Steam](https://steamcommunity.com/id/kasull/) | [GitHub](https://github.com/kasullian) :: programming, reverse engineering, trailer production
-- __Alienmario__ :: [Steam](https://steamcommunity.com/id/4oM0/) | [GitHub](https://github.com/Alienmario) :: programming, reverse engineering, map editing
-- __Balimbanana__ :: [Steam](https://steamcommunity.com/id/Balimbanana/) | [GitHub](https://github.com/Balimbanana) :: programming, reverse engineering
-- __Rock__ :: [Steam](https://steamcommunity.com/id/Rock48/) | [GitHub](https://github.com/Rock48) :: programming, map editing
-- __Krozis Kane__ :: [Steam](https://steamcommunity.com/id/Krozis_Kane/) | [GitHub](https://github.com/KrozisKane) :: map editing
-- __ReservedRegister__ :: [GitHub](https://github.com/ReservedRegister) :: reverse engineering
-- __raicovx__ :: [Github](https://github.com/raicovx) :: equipment persistence
-- __Jimmy-Baby__ :: [Github](https://github.com/Jimmy-Baby) :: damage effects addon
-- __Removiekeen__ :: [Steam](https://steamcommunity.com/profiles/76561198804614641/) :: logo design
-- __yarik2720__ :: [Github](https://github.com/yarik2720) :: russian translation, ci/cd
-
-### External Libraries
-
-- [SourceMod](https://github.com/alliedmodders/sourcemod)
-- [SourceScramble](https://github.com/nosoop/SMExt-SourceScramble)
-- [stocksoup](https://github.com/nosoop/stocksoup)
-- [sm-logdebug](https://github.com/Alienmario/sm-logdebug)
-- [smlib](https://github.com/bcserv/smlib/tree/transitional_syntax)
+#### Third-party libraries
+[SourceMod](https://github.com/alliedmodders/sourcemod)
+| [SourceScramble](https://github.com/nosoop/SMExt-SourceScramble)
+| [stocksoup](https://github.com/nosoop/stocksoup)
+| [sm-logdebug](https://github.com/Alienmario/sm-logdebug)
+| [smlib](https://github.com/bcserv/smlib/tree/transitional_syntax)

--- a/gamedata/srccoop.games.txt
+++ b/gamedata/srccoop.games.txt
@@ -21,6 +21,12 @@
 				"windows"	"IEngineSoundServer003"
 				"linux"		"IEngineSoundServer003"
 			}
+
+			"CSoundSize"
+			{
+				"windows"	"52"
+				"linux"		"52"
+			}
 		}
 		"Offsets"
 		{
@@ -550,6 +556,20 @@
 				"return"	"void"
 				"this"		"entity"
 			}
+			"CAI_BaseNPC::UpdateSleepState"
+			{
+				"signature"	"CAI_BaseNPC::UpdateSleepState"
+				"callconv"	"thiscall"
+				"return"	"void"
+				"this"		"entity"
+				"arguments"
+				{
+					"bInPVS"
+					{
+						"type"	"bool"
+					}
+				}
+			}
 			"CBoneSetup::AccumulatePose"
 			{
 				"signature"	"CBoneSetup::AccumulatePose"
@@ -717,6 +737,11 @@
 				"windows"	"\x55\x8B\xEC\x83\xEC\x5C\x53\x57\x8B\xF9"
 				"linux" 	"@_ZN11CAI_BaseNPC19SetPlayerAvoidStateEv"
 			}
+			"CAI_BaseNPC::UpdateSleepState"	// void CAI_BaseNPC::UpdateSleepState( bool bInPVS )
+			{
+				"windows"	"\x55\x8B\xEC\x56\x8B\xF1\x83\xBE\x8C\x09\x00\x00\x00\x2A\x2A\x2A\x2A\x2A\x2A\xA1\xD0\x91"	// str: "CAI_BaseNPC::UpdateSleepState called with NULL pLocalPlayer\n"
+				"linux"		"@_ZN11CAI_BaseNPC16UpdateSleepStateEb"
+			}
 			"CreateServerRagdoll" // CBaseEntity CreateServerRagdoll(CBaseAnimating *, int, const CTakeDamageInfo *, int, bool)
 			{
 				"windows"	"\x53\x8B\xDC\x83\xEC\x08\x83\xE4\xF0\x83\xC4\x04\x55\x8B\x6B\x04\x89\x6C\x24\x04\x8B\xEC\xB8\x78\x30\x00\x00"
@@ -878,6 +903,21 @@
 				"windows"	"468"
 				"linux"		"469"
 			}
+			"CAI_BaseNPC::QueryHearSound"	// bool CAI_BaseNPC::QueryHearSound(CSound*)
+			{
+				"windows"	"420"
+				"linux"		"421"
+			}
+			"CAI_BaseNPC::GetSoundInterests"	// int CAI_BaseNPC::GetSoundInterests( void )
+			{
+				"windows"	"426"
+				"linux"		"427"
+			}
+			"CAI_BaseNPC::HearingSensitivity"	// float CAI_BaseNPC::HearingSensitivity()
+			{
+				"windows"	"430"
+				"linux"		"431"
+			}
 			"CAI_BaseNPC::UpdateEnemyMemory" // CAI_BaseNPC::UpdateEnemyMemory(CBaseEntity*, Vector const&, CBaseEntity*)
 			{
 				"windows"	"529"
@@ -1017,6 +1057,11 @@
 			{
 				"windows"	"\x55\x8B\xEC\x83\xEC\x5C\x53\x57"
 				"linux" 	"@_ZN11CAI_BaseNPC19SetPlayerAvoidStateEv"
+			}
+			"CAI_BaseNPC::UpdateSleepState"	// void CAI_BaseNPC::UpdateSleepState( bool bInPVS )
+			{
+				"windows"	"\x55\x8B\xEC\x56\x8B\xF1\x83\xBE\x3C\x09\x00\x00\x00\x2A\x2A\x2A\x2A\x2A\x2A\xA1\x50"	// str: "CAI_BaseNPC::UpdateSleepState called with NULL pLocalPlayer\n"
+				"linux"		"@_ZN11CAI_BaseNPC16UpdateSleepStateEb"
 			}
 			"GlobalEntity_GetIndex" // int GlobalEntity_GetIndex( const char *pGlobalname );
 			{
@@ -1191,6 +1236,21 @@
 			{
 				"windows"	"31"
 				"linux"		"30"
+			}
+			"CAI_BaseNPC::QueryHearSound"	// bool CAI_BaseNPC::QueryHearSound(CSound*)
+			{
+				"windows"	"387"
+				"linux"		"388"
+			}
+			"CAI_BaseNPC::GetSoundInterests"	// int CAI_BaseNPC::GetSoundInterests( void )
+			{
+				"windows"	"393"
+				"linux"		"394"
+			}
+			"CAI_BaseNPC::HearingSensitivity"	// float CAI_BaseNPC::HearingSensitivity()
+			{
+				"windows"	"397"
+				"linux"		"398"
 			}
 			"CAI_BaseNPC::UpdateEnemyMemory" // CAI_BaseNPC::UpdateEnemyMemory(CBaseEntity*, Vector const&, CBaseEntity*)
 			{

--- a/scripting/include/srccoop.inc
+++ b/scripting/include/srccoop.inc
@@ -42,6 +42,7 @@
 	#define ENTPATCH_GOALENTITY_RESOLVENAMES
 	#define ENTPATCH_GOAL_LEAD
 	#define ENTPATCH_SETPLAYERAVOIDSTATE
+	#define ENTPATCH_NPC_SLEEP
 	#define ENTPATCH_FUNC_TRACKAUTOCHANGE
 	#define ENTPATCH_FUNC_TRACKTRAIN
 	
@@ -88,6 +89,7 @@
 	#define ENTPATCH_GOALENTITY_RESOLVENAMES
 	#define ENTPATCH_GOAL_LEAD
 	#define ENTPATCH_SETPLAYERAVOIDSTATE
+	#define ENTPATCH_NPC_SLEEP
 	#define ENTPATCH_BM_XENTURRET
 	#define ENTPATCH_BM_ICHTHYOSAUR
 	#define ENTPATCH_BM_GARGANTUA
@@ -159,7 +161,11 @@
 #include <srccoop/entitypatch>
 #if defined SRCCOOP_BLACKMESA
 #include <srccoop/blackmesa/entitypatch>
+#include <srccoop/blackmesa/deathnotice>
+#elseif defined SRCCOOP_HL2DM
+#include <srccoop/hl2dm/deathnotice>
 #endif
+#include <srccoop/deathnotice>
 #include <srccoop/instancing>
 #include <srccoop/playerpatch>
 #include <srccoop/menu>

--- a/scripting/include/srccoop/blackmesa/deathnotice.inc
+++ b/scripting/include/srccoop/blackmesa/deathnotice.inc
@@ -90,6 +90,7 @@ char g_pDnDisplayList[][2][] =
 	{ "prop_xen_int_barrel", "Physics Prop" },
 	{ "prop_barrel_cactus", "Cactus" },
 	{ "prop_barrel_cactus_semilarge", "Cactus" },
+	{ "func_minefield", "Landmine" },
 
 	// Weapon Projectiles.
 	{ "grenade_bolt", "Crossbow Bolt" },
@@ -150,11 +151,12 @@ char g_pDnWeaponIconList[][2][] =
 // func_door
 // func_tow
 // func_tow_mp
-// func_minefield
 
 // grenade_nuke
+
 // grenade_spit
 // grenade_tank_shell
 // grenade_tow
+
 
 // proto_sniper

--- a/scripting/include/srccoop/blackmesa/deathnotice.inc
+++ b/scripting/include/srccoop/blackmesa/deathnotice.inc
@@ -1,0 +1,127 @@
+#if defined _srccoop_deathnotice_game_included
+ #endinput
+#endif
+#define _srccoop_deathnotice_game_included
+
+#pragma newdecls required
+#pragma semicolon 1
+
+char g_pDnDisplayList[][2][] = 
+{
+	{ "npc_abrams", "HECU Tank" },
+	{ "npc_alien_controller", "Alien Controller" },
+	{ "npc_alien_grunt", "Alien Grunt" },
+	{ "npc_alien_grunt_elite", "Elite Alien Grunt" },
+	{ "npc_alien_grunt_melee", "Alien Grunt" },
+	{ "npc_alien_slave", "Alien Slave" },
+	{ "npc_alien_slave_dummy", "Alien Slave" },
+	{ "npc_apache", "HECU Apache" },
+	{ "npc_barnacle", "Barnacle" },
+	{ "npc_beneathticle", "Underwater Barnacle" },	// BUG: crashes server with following message: "865/ - gib: UTIL_SetModel:  not precached: models/gibs/hgibs_rib.mdl"
+	{ "npc_boid", "Boid" },
+	{ "npc_boid_flock", "Boid Flock" },
+	{ "npc_bullsquid", "Bullsquid" },
+	{ "npc_bullsquid_melee", "Bullsquid" },
+	{ "npc_crow", "Crow" },
+	{ "npc_eli", "Dr. Eli" },
+	{ "npc_furniture", "Furniture" },
+	{ "npc_gargantua", "Gargantua" },
+	{ "npc_Gonarch", "Gonarch" },
+	{ "npc_headcrab", "Headcrab" },
+	{ "npc_headcrab_baby", "Baby Headcrab" },
+	{ "npc_headcrab_black", "Poison Headcrab" },
+	{ "npc_headcrab_fast", "Fast Headcrab" },
+	{ "npc_headcrab_poison", "Poison Headcrab" },
+	{ "npc_hecu_marine", "HECU Marine" },
+	{ "npc_houndeye", "Houndeye" },
+	{ "npc_houndeye_knockback", "Knockback Houndeye" },
+	{ "npc_houndeye_suicide", "Explosive Houndeye" },
+	{ "npc_human_assassin", "Black Ops Assassin" },
+	{ "npc_human_commander", "HECU Commander" },
+	{ "npc_human_grenadier", "HECU Marine" },
+	{ "npc_human_grunt", "HECU Marine" },
+	{ "npc_human_medic", "HECU Marine" },
+	{ "npc_human_scientist", "Scientist" },
+	{ "npc_human_scientist_eli", "Dr. Eli" },
+	{ "npc_human_scientist_female", "Scientist" },
+	{ "npc_human_scientist_kleiner", "Dr. Kleiner" },
+	{ "npc_human_security", "Security Guard" },
+	{ "npc_ichthyosaur", "Ichthyosaur" },
+	{ "npc_kleiner", "Dr. Kliener" },
+	{ "npc_lav", "HECU LAV" },
+	{ "npc_leech", "Leech" },
+	{ "npc_nihilanth", "Nihilanth" },
+	{ "npc_osprey", "HECU Osprey" },
+	{ "npc_pigeon", "Pigeon" },
+	{ "npc_plantlight", "Plantlight" },
+	{ "npc_plantlight_stalker", "Plantlight" },
+	{ "npc_protozoan", "Protozoan" },
+	{ "npc_puffballfungus", "Puffball Fungus" },
+	{ "npc_seagull", "Seagull" },
+	{ "npc_sentry_ceiling", "Turret" },
+	{ "npc_sentry_ground", "Turret" },
+	{ "npc_snark", "Snark" },
+	{ "npc_sniper", "HECU Sniper" },
+	{ "npc_template_maker", "" },
+	{ "npc_tentacle", "Alien Tentacle" },
+	{ "npc_vortigaunt", "Alien Slave" },
+	{ "npc_xen_grunt", "Alien Grunt" },
+	{ "npc_xentacle", "Alien Tentacle" },
+	{ "npc_xentree", "Alien Tree" },
+	{ "npc_xenturret", "Alien Turret" },
+	{ "npc_xontroller", "Alien Xontroller" },
+	{ "npc_xort", "Alien Slave" },
+	{ "npc_xortEB", "Alien Slave" },
+	{ "npc_zombie_grunt", "Zombie" },
+	{ "npc_zombie_grunt_torso", "Zombie" },
+	{ "npc_zombie_hev", "Zombie" },
+	{ "npc_zombie_scientist", "Zombie" },
+	{ "npc_zombie_scientist_torso", "Zombie" },
+	{ "npc_zombie_security", "Zombie" },
+	
+	{ "env_beam", "Laser Beam" },
+	{ "env_explosion", "Explosion" },
+	{ "env_fire", "Fire" },
+	{ "env_laser", "Laser Beam" },
+	{ "entityflame", "Fire" },
+	{ "func_movelinear", "Moving Prop" },
+	{ "prop_physics", "Physics Prop" },
+	{ "grenade_mortar_small", "HECU Mortar" },
+	{ "grenade_tripmine", "HECU Tripmine" },
+};
+
+char g_pDnWeaponDisplayList[][2][] =
+{
+	{ "weapon_357", "357" },
+	{ "weapon_assassin_glock", "assassin_glock" },
+	{ "weapon_crossbow", "crossbow" },
+	{ "weapon_crowbar", "crowbar" },
+	{ "weapon_frag", "frag" },
+	{ "weapon_glock", "glock" },
+	{ "weapon_gluon", "gluon" },
+	{ "weapon_headcrab", "headcrab" },
+	{ "weapon_hivehand", "hivehand" },
+	{ "weapon_mp5", "mp5" },
+	{ "weapon_rpg", "rpg" },
+	{ "weapon_satchel", "satchel" },
+	{ "weapon_shotgun", "shotgun" },
+	{ "weapon_snark", "snark" },
+	{ "weapon_tau", "tau" },
+	{ "weapon_tripmine", "tripmine" },
+
+	{ "grenade_bolt", "crossbow" },
+	{ "grenade_frag", "frag" },
+	{ "grenade_hornet", "hivehand" },
+	{ "grenade_mp5_contact", "mp5" },
+	{ "grenade_rpg", "rpg" },
+	{ "grenade_apache_rpg", "rpg" },
+	{ "grenade_satchel", "satchel" },
+	{ "grenade_tripmine", "tripmine" },
+	{ "npc_snark", "snark" },
+};
+
+// todo: check the following
+// prop_xen_int_barrel
+// prop_barrel_cactus
+// prop_barrel_cactus_semilarge
+// grenade_frag classname

--- a/scripting/include/srccoop/blackmesa/deathnotice.inc
+++ b/scripting/include/srccoop/blackmesa/deathnotice.inc
@@ -8,16 +8,17 @@
 
 char g_pDnDisplayList[][2][] = 
 {
-	{ "npc_abrams", "HECU Tank" },
+	// NPCS.
+	{ "npc_abrams", "Tank" },
 	{ "npc_alien_controller", "Alien Controller" },
 	{ "npc_alien_grunt", "Alien Grunt" },
 	{ "npc_alien_grunt_elite", "Elite Alien Grunt" },
 	{ "npc_alien_grunt_melee", "Alien Grunt" },
 	{ "npc_alien_slave", "Alien Slave" },
 	{ "npc_alien_slave_dummy", "Alien Slave" },
-	{ "npc_apache", "HECU Apache" },
+	{ "npc_apache", "Apache" },
 	{ "npc_barnacle", "Barnacle" },
-	{ "npc_beneathticle", "Underwater Barnacle" },	// BUG: crashes server with following message: "865/ - gib: UTIL_SetModel:  not precached: models/gibs/hgibs_rib.mdl"
+	{ "npc_beneathticle", "Underwater Barnacle" },
 	{ "npc_boid", "Boid" },
 	{ "npc_boid_flock", "Boid Flock" },
 	{ "npc_bullsquid", "Bullsquid" },
@@ -32,15 +33,15 @@ char g_pDnDisplayList[][2][] =
 	{ "npc_headcrab_black", "Poison Headcrab" },
 	{ "npc_headcrab_fast", "Fast Headcrab" },
 	{ "npc_headcrab_poison", "Poison Headcrab" },
-	{ "npc_hecu_marine", "HECU Marine" },
+	{ "npc_hecu_marine", "HECU Soldier" },
 	{ "npc_houndeye", "Houndeye" },
 	{ "npc_houndeye_knockback", "Knockback Houndeye" },
 	{ "npc_houndeye_suicide", "Explosive Houndeye" },
-	{ "npc_human_assassin", "Black Ops Assassin" },
+	{ "npc_human_assassin", "Assassin" },
 	{ "npc_human_commander", "HECU Commander" },
-	{ "npc_human_grenadier", "HECU Marine" },
-	{ "npc_human_grunt", "HECU Marine" },
-	{ "npc_human_medic", "HECU Marine" },
+	{ "npc_human_grenadier", "HECU Soldier" },
+	{ "npc_human_grunt", "HECU Soldier" },
+	{ "npc_human_medic", "HECU Soldier" },
 	{ "npc_human_scientist", "Scientist" },
 	{ "npc_human_scientist_eli", "Dr. Eli" },
 	{ "npc_human_scientist_female", "Scientist" },
@@ -48,10 +49,10 @@ char g_pDnDisplayList[][2][] =
 	{ "npc_human_security", "Security Guard" },
 	{ "npc_ichthyosaur", "Ichthyosaur" },
 	{ "npc_kleiner", "Dr. Kliener" },
-	{ "npc_lav", "HECU LAV" },
+	{ "npc_lav", "LAV" },
 	{ "npc_leech", "Leech" },
 	{ "npc_nihilanth", "Nihilanth" },
-	{ "npc_osprey", "HECU Osprey" },
+	{ "npc_osprey", "Osprey" },
 	{ "npc_pigeon", "Pigeon" },
 	{ "npc_plantlight", "Plantlight" },
 	{ "npc_plantlight_stalker", "Plantlight" },
@@ -61,8 +62,7 @@ char g_pDnDisplayList[][2][] =
 	{ "npc_sentry_ceiling", "Turret" },
 	{ "npc_sentry_ground", "Turret" },
 	{ "npc_snark", "Snark" },
-	{ "npc_sniper", "HECU Sniper" },
-	{ "npc_template_maker", "" },
+	{ "npc_sniper", "Marine Sniper" },
 	{ "npc_tentacle", "Alien Tentacle" },
 	{ "npc_vortigaunt", "Alien Slave" },
 	{ "npc_xen_grunt", "Alien Grunt" },
@@ -79,19 +79,38 @@ char g_pDnDisplayList[][2][] =
 	{ "npc_zombie_scientist_torso", "Zombie" },
 	{ "npc_zombie_security", "Zombie" },
 	
+	// Entities.
 	{ "env_beam", "Laser Beam" },
 	{ "env_explosion", "Explosion" },
 	{ "env_fire", "Fire" },
 	{ "env_laser", "Laser Beam" },
 	{ "entityflame", "Fire" },
-	{ "func_movelinear", "Moving Prop" },
+	{ "func_movelinear", "Dynamic Prop" },
 	{ "prop_physics", "Physics Prop" },
-	{ "grenade_mortar_small", "HECU Mortar" },
-	{ "grenade_tripmine", "HECU Tripmine" },
+	{ "prop_xen_int_barrel", "Physics Prop" },
+	{ "prop_barrel_cactus", "Cactus" },
+	{ "prop_barrel_cactus_semilarge", "Cactus" },
+
+	// Weapon Projectiles.
+	{ "grenade_bolt", "Crossbow Bolt" },
+	{ "grenade_frag", "Frag Grenade" },
+	{ "grenade_hornet", "Hornet" },
+	{ "grenade_mp5_contact", "MP5 Grenade" },
+	{ "grenade_rpg", "RPG" },
+	{ "grenade_apache_rpg", "Apache" },
+	{ "grenade_satchel", "Satchel" },
+	{ "grenade_tripmine", "Tripmine" },
+	{ "npc_snark", "Snark" },
+	
+	// Entity Projectiles.
+	{ "grenade_mortar", "Mortar Shell" },
+	{ "grenade_mortar_small", "Mortar Shell" },
+	{ "grenade_mortar_large", "Mortar Shell" },
 };
 
-char g_pDnWeaponDisplayList[][2][] =
+char g_pDnWeaponIconList[][2][] =
 {
+	// Weapons.
 	{ "weapon_357", "357" },
 	{ "weapon_assassin_glock", "assassin_glock" },
 	{ "weapon_crossbow", "crossbow" },
@@ -109,6 +128,7 @@ char g_pDnWeaponDisplayList[][2][] =
 	{ "weapon_tau", "tau" },
 	{ "weapon_tripmine", "tripmine" },
 
+	// Weapon Projectiles.
 	{ "grenade_bolt", "crossbow" },
 	{ "grenade_frag", "frag" },
 	{ "grenade_hornet", "hivehand" },
@@ -120,8 +140,21 @@ char g_pDnWeaponDisplayList[][2][] =
 	{ "npc_snark", "snark" },
 };
 
-// todo: check the following
-// prop_xen_int_barrel
-// prop_barrel_cactus
-// prop_barrel_cactus_semilarge
-// grenade_frag classname
+// TODO:
+// Check the following:
+// 
+// env_gunfire
+// env_mortar_launcher
+// env_sporeexplosion
+// func_50cal
+// func_door
+// func_tow
+// func_tow_mp
+// func_minefield
+
+// grenade_nuke
+// grenade_spit
+// grenade_tank_shell
+// grenade_tow
+
+// proto_sniper

--- a/scripting/include/srccoop/classdef.inc
+++ b/scripting/include/srccoop/classdef.inc
@@ -2392,21 +2392,17 @@ methodmap CTraceRay < Handle
 		return view_as<CTraceRay>(TR_TraceRayFilterEx(vecPosition, vecRayType, iTraceMask, eRayType, fnFilter, pData));
 	}
 
-	public Handle GetHandle()
-	{
-		return view_as<Handle>(this);
-	}
 	public bool StartedSolid()
 	{
-		return TR_StartSolid(this.GetHandle());
+		return TR_StartSolid(this);
 	}
 	public float GetFraction()
 	{
-		return TR_GetFraction(this.GetHandle());
+		return TR_GetFraction(this);
 	}
 	public CBaseEntity GetEntity()
 	{
-		return CBaseEntity(TR_GetEntityIndex(this.GetHandle()));
+		return CBaseEntity(TR_GetEntityIndex(this));
 	}
 }
 

--- a/scripting/include/srccoop/classdef.inc
+++ b/scripting/include/srccoop/classdef.inc
@@ -2462,14 +2462,13 @@ Address GetSoundPoolPropAddress(CSoundEnt pSoundEnt, const int iSoundIndex, cons
 		ThrowError("Unable to retrieve offset %s", "m_SoundPool");
 
 	// obtain the offset within `CSound`
-	int iOffset = FindDataMapInfo(pSoundEnt.GetEntIndex(), szProperty);
-	if (iOffset == -1)
+	int iOffsetFromStartProperty = FindDataMapInfo(pSoundEnt.GetEntIndex(), szProperty);
+	if (iOffsetFromStartProperty == -1)
 		ThrowError("Unable to retrieve offset %s", szProperty);
-	else
-		iOffset -= iOffsetPoolStart;
 	
-	if (iOffset <= 0)
-		ThrowError("Internal Error: Unable to retrive offset %s", szProperty);
+	int iOffset = iOffsetFromStartProperty - iOffsetPoolStart;
+	if (iOffset < 0)
+		ThrowError("Internal Error: Computed offset %s is negative (%i); %s offset: %i, SoundPool offset: %i", szProperty, iOffset, szProperty, iOffsetFromStartProperty, iOffsetPoolStart);
 	
 	// this + offsetof(m_SoundPool[iSoundIndex]) + offsetof(property)
 	return pSoundEnt.GetAddress() + iOffsetPoolStart + iSoundIndex * g_iCSoundSize + iOffset;

--- a/scripting/include/srccoop/classdef.inc
+++ b/scripting/include/srccoop/classdef.inc
@@ -8,6 +8,8 @@
 #pragma newdecls required
 #pragma semicolon 1
 
+ConVar ai_los_mode;
+
 Handle g_pGlobalEntityGetIndex;
 Handle g_pGlobalEntityGetState;
 Handle g_pGlobalEntityGetName;
@@ -35,6 +37,8 @@ int g_iCSoundSize = -1;
 
 stock void InitClassdef(GameData pGameConfig)
 {
+	ai_los_mode = FindConVar("ai_los_mode");
+
 	g_iCSoundSize = GetGamedataInt(pGameConfig, "CSoundSize");
 	if (g_iCSoundSize <= 0)
 		SetFailState("Could not obtain CSound struct size");
@@ -296,23 +300,6 @@ methodmap CBaseEntity
 	{
 		return CBaseEntity(CreateEntityByName(szClassname));
 	}
-	//public static CBaseEntity FromAddress(const Address pAddress)
-	//{
-	//	// Credits: stocksoup: memory.inc -> int GetEntityFromAddress(Address pEntity)
-	//	// CWorld is derived from CBaseEntity so it should have both offsets
-	//	int iOffsetAngleRotation = FindDataMapInfo(0, "m_angRotation");
-	//	if (iOffsetAngleRotation == -1)
-	//		ThrowError("Unable to retrieve offset %s", "m_angRotation");
-	//	int iOffsetViewOffset = FindDataMapInfo(0, "m_vecViewOffset");
-	//	if (iOffsetViewOffset == -1)
-	//		ThrowError("Unable to retrieve offset %s", "m_vecViewOffset");
-	//	
-	//	if ((iOffsetAngleRotation + 0x0C) != (iOffsetViewOffset - 0x04))
-	//		ThrowError("Unable to confirm offset %s", "m_RefEHandle");
-	//	
-	//	Address pEHandle = pAddress + iOffsetAngleRotation + 0x0C;
-	//	return CBaseEntity(LoadFromAddress(pEHandle, NumberType_Int32) | (1 << 31));
-	//}
 
 	property int entindex
 	{
@@ -448,15 +435,19 @@ methodmap CBaseEntity
 		}
 		else
 		{
+			float vec3Origin[3];
+			this.GetAbsOrigin(vec3Origin);
+
 			float vec3Offset[3];
 			GetEntPropVector(this.GetEntIndex(), Prop_Data, "m_vecViewOffset", vec3Offset);
-			
-			this.GetAbsOrigin(vecBuffer);
-			vecBuffer[0] += vec3Offset[0];
-			vecBuffer[1] += vec3Offset[1];
-			vecBuffer[2] += vec3Offset[2];
+
+			AddVectors(vec3Origin, vec3Offset, vecBuffer);
 		}
 	}
+	// # Citations
+	//
+	// - [Source SDK 2013](https://github.com/ValveSoftware/source-sdk-2013/blob/0d8dceea4310fde5706b3ce1c70609d72a38efdf/mp/src/game/shared/baseentity_shared.cpp#L148)
+	//
 	public void GetEarPosition(float vecBuffer[3])
 	{
 		this.GetEyePosition(vecBuffer);
@@ -831,7 +822,7 @@ methodmap CBaseEntity
 		pEntity.GetEyePosition(vec3TargetOrigin);
 
 		CTraceRay pTraceRay;
-		if (FindConVar("ai_los_mode").BoolValue)	// TODO: Cache this ConVar.
+		if (ai_los_mode.BoolValue)
 		{
 			pTraceRay = new CTraceRay(vec3LookerOrigin, vec3TargetOrigin, iTraceMask, RayType_EndPoint, TraceEntityFilter_FVisibleAiLosEnabled, this.GetEntIndex());
 		}
@@ -887,7 +878,7 @@ methodmap CBaseEntity
 		this.GetEyePosition(vec3LookerOrigin);
 
 		CTraceRay pTraceRay;
-		if (FindConVar("ai_los_mode").BoolValue)	// TODO: Cache this ConVar.
+		if (ai_los_mode.BoolValue)
 		{
 			pTraceRay = new CTraceRay(vec3LookerOrigin, vec3TargetOrigin, iTraceMask, RayType_EndPoint, TraceEntityFilter_FVisibleAiLosEnabled, this.GetEntIndex());
 		}
@@ -1059,19 +1050,19 @@ methodmap CSoundEnt < CPointEntity
 	// Gets the index of the first sound in the active sound list.
 	public void ActiveList(CSound pSound)
 	{
-		pSound.m_pSoundEnt = view_as<int>(this);
+		pSound.m_pSoundEnt = this;
 		pSound.m_iSoundIndex = GetEntProp(this.GetEntIndex(), Prop_Data, "m_iActiveSound");
 	}
 }
 
 enum struct CSound
 {
-	int m_pSoundEnt;
+	CSoundEnt m_pSoundEnt;
 	int m_iSoundIndex;
 
 	CSoundEnt GetSoundEnt()
 	{
-		return view_as<CSoundEnt>(this.m_pSoundEnt);
+		return this.m_pSoundEnt;
 	}
 	int GetSoundIndex()
 	{
@@ -1526,7 +1517,9 @@ methodmap CAI_BaseNPC < CBaseCombatCharacter
 	}
 	public void Sleep()
 	{
-		this.AcceptInputStr("Sleep");
+		// TODO:
+		// Reconstruct function from scratch.
+		// https://github.com/ValveSoftware/source-sdk-2013/blob/0d8dceea4310fde5706b3ce1c70609d72a38efdf/mp/src/game/server/ai_basenpc.cpp#L4440
 	}
 	public CBaseEntity GetEnemy()
 	{
@@ -1554,7 +1547,7 @@ methodmap CAI_BaseNPC < CBaseCombatCharacter
 	}
 	public bool HasCondition(const int iCondition)
 	{
-		bool bOutOfBounds = view_as<bool>((iCondition > 255) || (iCondition < 0));
+		bool bOutOfBounds = (iCondition > 255) || (iCondition < 0);
 		if (bOutOfBounds)
 			ThrowError("Received out of bounds index %d; range is 0-255", iCondition);
 		
@@ -2190,62 +2183,54 @@ methodmap CPlayerResource < CBaseEntity
 	public int GetTeam(CBasePlayer pPlayer)
 	{
 		int iEntIndex = pPlayer.GetEntIndex();
-		bool bOutOfBounds = view_as<bool>((iEntIndex > MaxClients) || (iEntIndex < 0));
+		bool bOutOfBounds = (iEntIndex > MaxClients) || (iEntIndex < 0);
 		if (bOutOfBounds)
 			ThrowError("Received out of bounds index %d; range is 0-%i", MaxClients);
 		
-		int iConnectedOffset = GetEntSendPropOffs(this.GetEntIndex(), "m_bConnected");
-		if (iConnectedOffset == -1)
+		int iMemberOffset = GetEntSendPropOffs(this.GetEntIndex(), "m_bConnected");
+		if (iMemberOffset == -1)
 			ThrowError("Unable to retrieve offset %s", "m_iTeam");
 		
-		Address pAddress = this.GetAddress();
-		Address pOffset = view_as<Address>(view_as<int>(pAddress) + iConnectedOffset + iEntIndex * 4);
-		return LoadFromAddress(pOffset, NumberType_Int32);
+		return Deref(this.GetAddress() + iMemberOffset + (iEntIndex * 4), NumberType_Int32);
 	}
 	public void SetTeam(CBasePlayer pPlayer, const int iTeamNum)
 	{
 		int iEntIndex = pPlayer.GetEntIndex();
-		bool bOutOfBounds = view_as<bool>((iEntIndex > MaxClients) || (iEntIndex < 0));
+		bool bOutOfBounds = (iEntIndex > MaxClients) || (iEntIndex < 0);
 		if (bOutOfBounds)
 			ThrowError("Received out of bounds index %d; range is 0-%i", MaxClients);
 		
-		int iConnectedOffset = GetEntSendPropOffs(this.GetEntIndex(), "m_iTeam");
-		if (iConnectedOffset == -1)
+		int iMemberOffset = GetEntSendPropOffs(this.GetEntIndex(), "m_iTeam");
+		if (iMemberOffset == -1)
 			ThrowError("Unable to retrieve offset %s", "m_iTeam");
 		
-		Address pAddress = this.GetAddress();
-		Address pOffset = view_as<Address>(view_as<int>(pAddress) + iConnectedOffset + iEntIndex * 4);
-		StoreToAddress(pOffset, iTeamNum, NumberType_Int32);
+		StoreToAddress(this.GetAddress() + iMemberOffset + (iEntIndex * 4), iTeamNum, NumberType_Int32);
 	}
 	public bool IsConnected(CBasePlayer pPlayer)
 	{
 		int iEntIndex = pPlayer.GetEntIndex();
-		bool bOutOfBounds = view_as<bool>((iEntIndex > MaxClients) || (iEntIndex < 0));
+		bool bOutOfBounds = (iEntIndex > MaxClients) || (iEntIndex < 0);
 		if (bOutOfBounds)
 			ThrowError("Received out of bounds index %d; range is 0-%i", MaxClients);
 		
-		int iConnectedOffset = GetEntSendPropOffs(this.GetEntIndex(), "m_bConnected");
-		if (iConnectedOffset == -1)
+		int iMemberOffset = GetEntSendPropOffs(this.GetEntIndex(), "m_bConnected");
+		if (iMemberOffset == -1)
 			ThrowError("Unable to retrieve offset %s", "m_bConnected");
 		
-		Address pAddress = this.GetAddress();
-		Address pOffset = view_as<Address>(view_as<int>(pAddress) + iConnectedOffset + iEntIndex * 4);
-		return view_as<bool>(LoadFromAddress(pOffset, NumberType_Int32));
+		return view_as<bool>(Deref(this.GetAddress() + iMemberOffset + (iEntIndex * 4), NumberType_Int32));
 	}
 	public void SetConnected(CBasePlayer pPlayer, const bool bConnected)
 	{
 		int iEntIndex = pPlayer.GetEntIndex();
-		bool bOutOfBounds = view_as<bool>((iEntIndex > MaxClients) || (iEntIndex < 0));
+		bool bOutOfBounds = (iEntIndex > MaxClients) || (iEntIndex < 0);
 		if (bOutOfBounds)
 			ThrowError("Received out of bounds index %d; range is 0-%i", MaxClients);
 		
-		int iConnectedOffset = GetEntSendPropOffs(this.GetEntIndex(), "m_bConnected");
-		if (iConnectedOffset == -1)
+		int iMemberOffset = GetEntSendPropOffs(this.GetEntIndex(), "m_bConnected");
+		if (iMemberOffset == -1)
 			ThrowError("Unable to retrieve offset %s", "m_bConnected");
 		
-		Address pAddress = this.GetAddress();
-		Address pOffset = view_as<Address>(view_as<int>(pAddress) + iConnectedOffset + iEntIndex * 4);
-		StoreToAddress(pOffset, view_as<int>(bConnected), NumberType_Int32);
+		StoreToAddress(this.GetAddress() + iMemberOffset + (iEntIndex * 4), view_as<int>(bConnected), NumberType_Int32);
 	}
 }
 

--- a/scripting/include/srccoop/classdef.inc
+++ b/scripting/include/srccoop/classdef.inc
@@ -296,6 +296,10 @@ methodmap CBaseEntity
 	{
 		return view_as<CBaseEntity>(iEntIndex > -1 ? EntIndexToEntRef(iEntIndex) : iEntIndex);
 	}
+	public static CBaseEntity FromAddress(const Address pAddress)
+	{
+		return CBaseEntity(GetEntityFromAddress(pAddress));
+	}
 	public static CBaseEntity Create(const char[] szClassname)
 	{
 		return CBaseEntity(CreateEntityByName(szClassname));

--- a/scripting/include/srccoop/classdef.inc
+++ b/scripting/include/srccoop/classdef.inc
@@ -18,6 +18,9 @@ Handle g_pGlobalEntitySetCounter;
 Handle g_pGlobalEntityAdd;
 Handle g_pGameShutdown;
 Handle g_pSetCollisionBounds;
+Handle g_pQueryHearSound;
+Handle g_pGetSoundInterests;
+Handle g_pHearingSensitivity;
 Handle g_pUpdateEnemyMemory;
 Handle g_pGetSequenceLinearMotion;
 Handle g_pShouldPlayerAvoid;
@@ -28,8 +31,14 @@ Handle g_pSendWeaponAnim;
 Handle g_pWeaponSwitch;
 Handle g_pWorldSpaceCenter;
 
+int g_iCSoundSize = -1;
+
 stock void InitClassdef(GameData pGameConfig)
 {
+	g_iCSoundSize = GetGamedataInt(pGameConfig, "CSoundSize");
+	if (g_iCSoundSize <= 0)
+		SetFailState("Could not obtain CSound struct size");
+
 	char szSetCollisionBounds[] = "CBaseEntity::SetCollisionBounds";
 	StartPrepSDKCall(SDKCall_Entity);
 	if (!PrepSDKCall_SetFromConf(pGameConfig, SDKConf_Signature, szSetCollisionBounds))
@@ -172,6 +181,37 @@ stock void InitClassdef(GameData pGameConfig)
 		if (!(g_pGameShutdown = EndPrepSDKCall())) SetFailState("Could not prep SDK call %s", szGameShutdown);
 	}
 
+	char szQueryHearSound[] = "CAI_BaseNPC::QueryHearSound";
+	StartPrepSDKCall(SDKCall_Entity);
+	if (!PrepSDKCall_SetFromConf(pGameConfig, SDKConf_Virtual, szQueryHearSound))
+		LogMessage("Could not obtain gamedata offset %s", szQueryHearSound);
+	else
+	{
+		PrepSDKCall_AddParameter(SDKType_PlainOldData, SDKPass_Plain);
+		PrepSDKCall_SetReturnInfo(SDKType_Bool, SDKPass_Plain);
+		if (!(g_pQueryHearSound = EndPrepSDKCall())) SetFailState("Could not prep SDK call %s", szQueryHearSound);
+	}
+
+	char szGetSoundInterests[] = "CAI_BaseNPC::GetSoundInterests";
+	StartPrepSDKCall(SDKCall_Entity);
+	if (!PrepSDKCall_SetFromConf(pGameConfig, SDKConf_Virtual, szGetSoundInterests))
+		LogMessage("Could not obtain gamedata offset %s", szGetSoundInterests);
+	else
+	{
+		PrepSDKCall_SetReturnInfo(SDKType_PlainOldData, SDKPass_Plain);
+		if (!(g_pGetSoundInterests = EndPrepSDKCall())) SetFailState("Could not prep SDK call %s", szGetSoundInterests);
+	}
+
+	char szHearingSensitivity[] = "CAI_BaseNPC::HearingSensitivity";
+	StartPrepSDKCall(SDKCall_Entity);
+	if (!PrepSDKCall_SetFromConf(pGameConfig, SDKConf_Virtual, szHearingSensitivity))
+		LogMessage("Could not obtain gamedata offset %s", szHearingSensitivity);
+	else
+	{
+		PrepSDKCall_SetReturnInfo(SDKType_Float, SDKPass_Plain);
+		if (!(g_pHearingSensitivity = EndPrepSDKCall())) SetFailState("Could not prep SDK call %s", szHearingSensitivity);
+	}
+
 	char szUpdateEnemyMemory[] = "CAI_BaseNPC::UpdateEnemyMemory";
 	StartPrepSDKCall(SDKCall_Entity);
 	if (!PrepSDKCall_SetFromConf(pGameConfig, SDKConf_Virtual, szUpdateEnemyMemory))
@@ -256,6 +296,23 @@ methodmap CBaseEntity
 	{
 		return CBaseEntity(CreateEntityByName(szClassname));
 	}
+	//public static CBaseEntity FromAddress(const Address pAddress)
+	//{
+	//	// Credits: stocksoup: memory.inc -> int GetEntityFromAddress(Address pEntity)
+	//	// CWorld is derived from CBaseEntity so it should have both offsets
+	//	int iOffsetAngleRotation = FindDataMapInfo(0, "m_angRotation");
+	//	if (iOffsetAngleRotation == -1)
+	//		ThrowError("Unable to retrieve offset %s", "m_angRotation");
+	//	int iOffsetViewOffset = FindDataMapInfo(0, "m_vecViewOffset");
+	//	if (iOffsetViewOffset == -1)
+	//		ThrowError("Unable to retrieve offset %s", "m_vecViewOffset");
+	//	
+	//	if ((iOffsetAngleRotation + 0x0C) != (iOffsetViewOffset - 0x04))
+	//		ThrowError("Unable to confirm offset %s", "m_RefEHandle");
+	//	
+	//	Address pEHandle = pAddress + iOffsetAngleRotation + 0x0C;
+	//	return CBaseEntity(LoadFromAddress(pEHandle, NumberType_Int32) | (1 << 31));
+	//}
 
 	property int entindex
 	{
@@ -382,6 +439,27 @@ methodmap CBaseEntity
 	public void SetSpawnFlags(const int iSpawnFlags)
 	{
 		SetEntProp(this.GetEntIndex(), Prop_Data, "m_spawnflags", iSpawnFlags);
+	}
+	public void GetEyePosition(float vecBuffer[3])
+	{
+		if (this.IsClassPlayer())
+		{
+			GetClientEyePosition(this.GetEntIndex(), vecBuffer);
+		}
+		else
+		{
+			float vec3Offset[3];
+			GetEntPropVector(this.GetEntIndex(), Prop_Data, "m_vecViewOffset", vec3Offset);
+			
+			this.GetAbsOrigin(vecBuffer);
+			vecBuffer[0] += vec3Offset[0];
+			vecBuffer[1] += vec3Offset[1];
+			vecBuffer[2] += vec3Offset[2];
+		}
+	}
+	public void GetEarPosition(float vecBuffer[3])
+	{
+		this.GetEyePosition(vecBuffer);
 	}
 	public int GetFlags()
 	{
@@ -742,6 +820,108 @@ methodmap CBaseEntity
 	{
 		SetEntProp(this.GetEntIndex(), Prop_Data, "m_iMaxHealth", iMaxHealth);
 	}
+	public bool FVisibleEntity(CBaseEntity pEntity, int iTraceMask = MASK_BLOCKLOS, CBaseEntity& pBlocker = NULL_CBASEENTITY)
+	{
+		if (pEntity.GetFlags() & FL_NOTARGET)
+			return false;
+
+		float vec3LookerOrigin[3];
+		this.GetEyePosition(vec3LookerOrigin);
+		float vec3TargetOrigin[3];
+		pEntity.GetEyePosition(vec3TargetOrigin);
+
+		CTraceRay pTraceRay;
+		if (FindConVar("ai_los_mode").BoolValue)	// TODO: Cache this ConVar.
+		{
+			pTraceRay = new CTraceRay(vec3LookerOrigin, vec3TargetOrigin, iTraceMask, RayType_EndPoint, TraceEntityFilter_FVisibleAiLosEnabled, this.GetEntIndex());
+		}
+		else
+		{
+			// If we're doing an LOS search, include NPCs.
+			if (iTraceMask == MASK_BLOCKLOS)
+			{
+				iTraceMask = MASK_BLOCKLOS_AND_NPCS;
+			}
+
+			// Player sees through nodraw
+			if (this.IsClassPlayer())
+			{
+				iTraceMask &= ~CONTENTS_BLOCKLOS;
+			}
+
+			pTraceRay = new CTraceRay(vec3LookerOrigin, vec3TargetOrigin, iTraceMask, RayType_EndPoint, TraceEntityFilter_FVisible, this.GetEntIndex());
+		}
+
+		if (pTraceRay.GetFraction() != 1.0 || pTraceRay.StartedSolid())
+		{
+			CBaseEntity pTracedEntity = pTraceRay.GetEntity();
+
+			// If we hit the entity we're looking for, it's visible
+			if (pEntity == pTracedEntity)
+			{
+				pTraceRay.Close();
+				return true;
+			}
+
+			if (pEntity.IsClassPlayer())
+			{
+				CBasePlayer pPlayer = view_as<CBasePlayer>(pEntity);
+				if (pPlayer.GetVehicle() == pTracedEntity)
+				{
+					// Got line of sight on the vehicle the player is driving!
+					pTraceRay.Close();
+					return true;
+				}
+			}
+
+			// Line of sight is not established
+			pBlocker = pTracedEntity;
+		}
+
+		pTraceRay.Close();
+		return false;
+	}
+	public bool FVisiblePosition(const float vec3TargetOrigin[3], int iTraceMask = MASK_BLOCKLOS, CBaseEntity& pBlocker = NULL_CBASEENTITY)
+	{
+		float vec3LookerOrigin[3];
+		this.GetEyePosition(vec3LookerOrigin);
+
+		CTraceRay pTraceRay;
+		if (FindConVar("ai_los_mode").BoolValue)	// TODO: Cache this ConVar.
+		{
+			pTraceRay = new CTraceRay(vec3LookerOrigin, vec3TargetOrigin, iTraceMask, RayType_EndPoint, TraceEntityFilter_FVisibleAiLosEnabled, this.GetEntIndex());
+		}
+		else
+		{
+			// If we're doing an LOS search, include NPCs.
+			if (iTraceMask == MASK_BLOCKLOS)
+			{
+				iTraceMask = MASK_BLOCKLOS_AND_NPCS;
+			}
+
+			// Player sees through nodraw
+			if (this.IsClassPlayer())
+			{
+				iTraceMask &= ~CONTENTS_BLOCKLOS;
+			}
+
+			pTraceRay = new CTraceRay(vec3LookerOrigin, vec3TargetOrigin, iTraceMask, RayType_EndPoint, TraceEntityFilter_FVisible, this.GetEntIndex());
+		}
+
+		if (pTraceRay.GetFraction() != 1.0)
+		{
+			// Line of sight is not established
+			pBlocker = pTraceRay.GetEntity();
+			pTraceRay.Close();
+			return false;
+		}
+		else
+		{
+			// line of sight is valid.
+			pTraceRay.Close();
+			return true;
+		}
+	}
 }
 
 enum struct FireOutputData
@@ -840,11 +1020,181 @@ methodmap CChangelevel < CBaseTrigger
 	}
 }
 
+methodmap CTriggerHurt < CBaseTrigger
+{
+	public CTriggerHurt(const int iEntIndex = -1)
+	{
+		return view_as<CTriggerHurt>(CBaseEntity(iEntIndex));
+	}
+
+	public int GetDamageType()
+	{
+		return GetEntProp(this.GetEntIndex(), Prop_Data, "m_bitsDamageInflict");
+	}
+}
+
 methodmap CSceneEntity < CBaseEntity
 {
 	public CSceneEntity(const int iEntIndex = -1)
 	{
 		return view_as<CSceneEntity>(CBaseEntity(iEntIndex));
+	}
+}
+
+methodmap CPointEntity < CBaseEntity
+{
+	public CPointEntity(const int iEntIndex = -1)
+	{
+		return view_as<CPointEntity>(CBaseEntity(iEntIndex));
+	}
+}
+
+methodmap CSoundEnt < CPointEntity
+{
+	public CSoundEnt(const int iEntIndex = -1)
+	{
+		return view_as<CSoundEnt>(CBaseEntity(iEntIndex));
+	}
+
+	// Gets the index of the first sound in the active sound list.
+	public void ActiveList(CSound pSound)
+	{
+		pSound.m_pSoundEnt = view_as<int>(this);
+		pSound.m_iSoundIndex = GetEntProp(this.GetEntIndex(), Prop_Data, "m_iActiveSound");
+	}
+}
+
+enum struct CSound
+{
+	int m_pSoundEnt;
+	int m_iSoundIndex;
+
+	CSoundEnt GetSoundEnt()
+	{
+		return view_as<CSoundEnt>(this.m_pSoundEnt);
+	}
+	int GetSoundIndex()
+	{
+		return this.m_iSoundIndex;
+	}
+	bool IsValid()
+	{
+		return this.GetSoundEnt().IsValid() && this.m_iSoundIndex >= 0 && this.m_iSoundIndex < MAX_WORLD_SOUNDS_MP;
+	}
+	Address GetAddress()
+	{
+		if (!this.IsValid())
+			ThrowError("Attempted to use invalid CSound index %i.", this.GetSoundIndex());
+		
+		CSoundEnt pSoundEnt = this.GetSoundEnt();
+		int iOffsetPoolStart = FindDataMapInfo(pSoundEnt.GetEntIndex(), "m_SoundPool");
+		if (iOffsetPoolStart == -1)
+			ThrowError("Unable to retrieve offset %s", "m_SoundPool");
+
+		return pSoundEnt.GetAddress() + iOffsetPoolStart + this.GetSoundIndex() * g_iCSoundSize;
+	}
+	int GetType()
+	{
+		if (!this.IsValid())
+			ThrowError("Attempted to use invalid CSound index %i.", this.GetSoundIndex());
+		
+		return LoadFromAddress(GetSoundPoolPropAddress(this.GetSoundEnt(), this.GetSoundIndex(), "m_iType"), NumberType_Int32);
+	}
+	int GetVolume()
+	{
+		if (!this.IsValid())
+			ThrowError("Attempted to use invalid CSound index %i.", this.GetSoundIndex());
+		
+		return LoadFromAddress(GetSoundPoolPropAddress(this.GetSoundEnt(), this.GetSoundIndex(), "m_iVolume"), NumberType_Int32);
+	}
+	CBaseEntity GetOwner()
+	{
+		if (!this.IsValid())
+			ThrowError("Attempted to use invalid CSound index %i.", this.GetSoundIndex());
+		
+		return CBaseEntity(LoadFromAddress(GetSoundPoolPropAddress(this.GetSoundEnt(), this.GetSoundIndex(), "m_hOwner"), NumberType_Int32)  | (1 << 31));
+	}
+	void Next()
+	{
+		if (!this.IsValid())
+			ThrowError("Attempted to use invalid CSound index %i.", this.GetSoundIndex());
+
+		this.m_iSoundIndex = LoadFromAddress(GetSoundPoolPropAddress(this.GetSoundEnt(), this.GetSoundIndex(), "m_iNext"), NumberType_Int16);
+	}
+	void GetOrigin(float vecBuffer[3])
+	{
+		if (!this.IsValid())
+			ThrowError("Attempted to use invalid CSound index %i.", this.GetSoundIndex());
+
+		Address pAddress = GetSoundPoolPropAddress(this.GetSoundEnt(), this.GetSoundIndex(), "m_vecOrigin");
+		vecBuffer[0] = LoadFromAddress(pAddress + 0x0, NumberType_Int32);
+		vecBuffer[1] = LoadFromAddress(pAddress + 0x4, NumberType_Int32);
+		vecBuffer[2] = LoadFromAddress(pAddress + 0x8, NumberType_Int32);
+	}
+	void GetSoundReactOrigin(float vecBuffer[3])
+	{
+		int iType = this.GetType();
+		if (iType == SOUND_BULLET_IMPACT || iType == SOUND_PHYSICS_DANGER)
+		{
+			CBaseEntity pOwner = this.GetOwner();
+			if (pOwner.IsValid())
+			{
+				pOwner.GetAbsOrigin(vecBuffer);
+			}
+			else
+			{
+				this.GetOrigin(vecBuffer);
+			}
+			return;
+		}
+
+		if (iType & SOUND_CONTEXT_REACT_TO_SOURCE)
+		{
+			CBaseEntity pOwner = this.GetOwner();
+			if (pOwner.IsValid())
+			{
+				pOwner.GetAbsOrigin(vecBuffer);
+				return;
+			}
+		}
+
+		if ((iType & SOUND_DANGER) && (iType & SOUND_CONTEXT_FROM_SNIPER))
+		{
+			CBaseEntity pOwner = this.GetOwner();
+			if (pOwner.IsValid())
+			{
+				pOwner.GetAbsOrigin(vecBuffer);
+				return;
+			}
+		}
+
+		this.GetOrigin(vecBuffer);
+	}
+}
+
+methodmap CPointHurt < CPointEntity
+{
+	public CPointHurt(const int iEntIndex = -1)
+	{
+		return view_as<CPointHurt>(CBaseEntity(iEntIndex));
+	}
+	
+	public int GetDamageType()
+	{
+		return GetEntProp(this.GetEntIndex(), Prop_Data, "m_bitsDamageType");
+	}
+}
+
+methodmap CLogicAchievement < CBaseEntity
+{
+	public CLogicAchievement(const int iEntIndex = -1)
+	{
+		return view_as<CLogicAchievement>(CBaseEntity(iEntIndex));
+	}
+
+	public bool GetAchievementEventID(char[] szBuffer, const int iMaxLength)
+	{
+		return view_as<bool>(GetEntPropString(this.GetEntIndex(), Prop_Data, "m_iszAchievementEventID", szBuffer, iMaxLength));
 	}
 }
 
@@ -987,6 +1337,14 @@ methodmap CPredictedViewModel < CBaseAnimating
 	}
 }
 
+methodmap CPropVehicleDriveable < CBaseAnimating
+{
+	public CPropVehicleDriveable(const int iEntIndex = -1)
+	{
+		return view_as<CPropVehicleDriveable>(CBaseEntity(iEntIndex));
+	}
+}
+
 methodmap CBaseCombatCharacter < CBaseAnimating
 {
 	public CBaseCombatCharacter(const int iEntIndex = -1)
@@ -1086,9 +1444,89 @@ methodmap CAI_BaseNPC < CBaseCombatCharacter
 		return view_as<CAI_BaseNPC>(CBaseEntity(iEntIndex));
 	}
 	
+	public int GetState()
+	{
+		return GetEntProp(this.GetEntIndex(), Prop_Data, "m_NPCState");
+	}
+	public bool IsInAScript()
+	{
+		return view_as<bool>(GetEntProp(this.GetEntIndex(), Prop_Data, "m_bInAScript"));
+	}
+	public bool IsSoundVisible(CSound pSound)
+	{
+		float vec3SoundReactOrigin[3];
+		pSound.GetSoundReactOrigin(vec3SoundReactOrigin);
+		CBaseEntity pBlocker = CBaseEntity();
+
+		return this.FVisiblePosition(vec3SoundReactOrigin, _, pBlocker) || (pBlocker.IsValid() && pBlocker == pSound.GetOwner());
+	}
+	public float GetHearingSensitivity()
+	{
+		return SDKCall(g_pHearingSensitivity, this);
+	}
+	public bool QueryHearSound(CSound pSound)
+	{
+		return SDKCall(g_pQueryHearSound, this, pSound.GetAddress());
+	}
+	public bool CanHearSound(CSound pSound)
+	{
+		if (this == pSound.GetOwner())
+			return false;
+		
+		if (this.GetState() == view_as<int>(NPC_STATE_SCRIPT) && (pSound.GetType() & SOUND_DANGER))
+			return false;
+		
+		if (this.IsInAScript())
+			return false;
+		
+		float vec3SoundOrigin[3];
+		pSound.GetOrigin(vec3SoundOrigin);
+		float vec3EarOrigin[3];
+		this.GetEarPosition(vec3EarOrigin);
+		float flDistance = GetVectorDistance(vec3SoundOrigin, vec3EarOrigin);
+		float flHearDistance = this.GetHearingSensitivity() * pSound.GetVolume();
+
+		return (flDistance <= flHearDistance) && this.QueryHearSound(pSound);
+	}
+	public float GetWakeRadius()
+	{
+		return GetEntPropFloat(this.GetEntIndex(), Prop_Data, "m_flWakeRadius");
+	}
+	public int GetSleepFlags()
+	{
+		return GetEntProp(this.GetEntIndex(), Prop_Data, "m_SleepFlags");
+	}
+	public int SetSleepFlags(const int iSleepFlags)
+	{
+		SetEntProp(this.GetEntIndex(), Prop_Data, "m_SleepFlags", iSleepFlags);
+	}
+	public bool HasSleepFlags(const int iSleepFlags)
+	{
+		return (this.GetSleepFlags() & iSleepFlags) == iSleepFlags;
+	}
+	public void AddSleepFlags(const int iSleepFlags)
+	{
+		this.SetSleepFlags(this.GetSleepFlags() | iSleepFlags);
+	}
+	public void RemoveSleepFlags(const int iSleepFlags)
+	{
+		this.SetSleepFlags(this.GetSleepFlags() & ~iSleepFlags);
+	}
+	public int GetSleepState()
+	{
+		return GetEntProp(this.GetEntIndex(), Prop_Data, "m_SleepState");
+	}
 	public void SetSleepState(const int iSleepState)
 	{
 		SetEntProp(this.GetEntIndex(), Prop_Data, "m_SleepState", iSleepState);
+	}
+	public void Wake()
+	{
+		this.AcceptInputStr("Wake");
+	}
+	public void Sleep()
+	{
+		this.AcceptInputStr("Sleep");
 	}
 	public CBaseEntity GetEnemy()
 	{
@@ -1097,6 +1535,10 @@ methodmap CAI_BaseNPC < CBaseCombatCharacter
 	public void SetEnemy(CBaseEntity pEntity)
 	{
 		SetEntPropEnt(this.GetEntIndex(), Prop_Data, "m_hEnemy", pEntity.GetEntIndex());
+	}
+	public int GetSoundInterests()
+	{
+		return SDKCall(g_pGetSoundInterests, this);
 	}
 	public bool UpdateEnemyMemory(CBaseEntity pEnemy, const float vecPosition[3], CBaseEntity pInformer)
 	{
@@ -1213,6 +1655,18 @@ methodmap CBasePlayer < CBaseCombatCharacter
 	{
 		return GetClientName(this.GetEntIndex(), szBuffer, iMaxLength);
 	}
+	public void SetName(const char[] szPlayerName)
+	{
+		SetClientName(this.GetEntIndex(), szPlayerName);
+	}
+	public int GetUserId()
+	{
+		return GetClientUserId(this.GetEntIndex());
+	}
+	public CPropVehicleDriveable GetVehicle()
+	{
+		return CPropVehicleDriveable(GetEntProp(this.GetEntIndex(), Prop_Send, "m_hVehicle"));
+	}
 	public int GetArmor()
 	{
 		return GetEntProp(this.GetEntIndex(), Prop_Data, "m_ArmorValue", 1);
@@ -1244,6 +1698,10 @@ methodmap CBasePlayer < CBaseCombatCharacter
 	public void SetSprintEnabled(const bool bSprintEnabled)
 	{
 		SetEntProp(this.GetEntIndex(), Prop_Send, "m_bSprintEnabled", bSprintEnabled);
+	}
+	public void Kick()
+	{
+		KickClient(this.GetEntIndex());
 	}
 	public CBaseAnimating GiveItem(const char[] szItemName)
 	{
@@ -1352,10 +1810,6 @@ methodmap CBasePlayer < CBaseCombatCharacter
 		this.SetViewOffset(vecViewOffset);
 		this.SetCollisionBounds(view_as<float>(VEC_HULL_MIN), view_as<float>(VEC_HULL_MAX));
 	}
-	public void GetEyePosition(float vecBuffer[3])
-	{
-		GetClientEyePosition(this.GetEntIndex(), vecBuffer);
-	}
 	public void GetEyeAngles(float vecBuffer[3])
 	{
 		GetClientEyeAngles(this.GetEntIndex(), vecBuffer);
@@ -1443,6 +1897,10 @@ methodmap CBasePlayer < CBaseCombatCharacter
 	public int GetTeam()
 	{
 		return GetClientTeam(this.GetEntIndex());
+	}
+	public void SetTeam(int iTeamIndex)
+	{
+		ChangeClientTeam(this.GetEntIndex(), iTeamIndex);
 	}
 	public CBaseEntity GetUseEntity()
 	{
@@ -1701,6 +2159,96 @@ methodmap CParticleSystem < CBaseEntity
 	}
 }
 
+methodmap CTeam < CBaseEntity
+{
+	public CTeam(const int iEntIndex = -1)
+	{
+		return view_as<CTeam>(CBaseEntity(iEntIndex));
+	}
+
+	public int GetTeam()
+	{
+		return GetEntProp(this.GetEntIndex(), Prop_Data, "m_iTeamNum");
+	}
+	public int GetScore()
+	{
+		return GetEntProp(this.GetEntIndex(), Prop_Send, "m_iScore");
+	}
+	public void SetScore(const int iScore)
+	{
+		SetEntProp(this.GetEntIndex(), Prop_Send, "m_iScore", iScore);
+	}
+}
+
+methodmap CPlayerResource < CBaseEntity
+{
+	public CPlayerResource(const int iEntIndex = -1)
+	{
+		return view_as<CPlayerResource>(CBaseEntity(iEntIndex));
+	}
+
+	public int GetTeam(CBasePlayer pPlayer)
+	{
+		int iEntIndex = pPlayer.GetEntIndex();
+		bool bOutOfBounds = view_as<bool>((iEntIndex > MaxClients) || (iEntIndex < 0));
+		if (bOutOfBounds)
+			ThrowError("Received out of bounds index %d; range is 0-%i", MaxClients);
+		
+		int iConnectedOffset = GetEntSendPropOffs(this.GetEntIndex(), "m_bConnected");
+		if (iConnectedOffset == -1)
+			ThrowError("Unable to retrieve offset %s", "m_iTeam");
+		
+		Address pAddress = this.GetAddress();
+		Address pOffset = view_as<Address>(view_as<int>(pAddress) + iConnectedOffset + iEntIndex * 4);
+		return LoadFromAddress(pOffset, NumberType_Int32);
+	}
+	public void SetTeam(CBasePlayer pPlayer, const int iTeamNum)
+	{
+		int iEntIndex = pPlayer.GetEntIndex();
+		bool bOutOfBounds = view_as<bool>((iEntIndex > MaxClients) || (iEntIndex < 0));
+		if (bOutOfBounds)
+			ThrowError("Received out of bounds index %d; range is 0-%i", MaxClients);
+		
+		int iConnectedOffset = GetEntSendPropOffs(this.GetEntIndex(), "m_iTeam");
+		if (iConnectedOffset == -1)
+			ThrowError("Unable to retrieve offset %s", "m_iTeam");
+		
+		Address pAddress = this.GetAddress();
+		Address pOffset = view_as<Address>(view_as<int>(pAddress) + iConnectedOffset + iEntIndex * 4);
+		StoreToAddress(pOffset, iTeamNum, NumberType_Int32);
+	}
+	public bool IsConnected(CBasePlayer pPlayer)
+	{
+		int iEntIndex = pPlayer.GetEntIndex();
+		bool bOutOfBounds = view_as<bool>((iEntIndex > MaxClients) || (iEntIndex < 0));
+		if (bOutOfBounds)
+			ThrowError("Received out of bounds index %d; range is 0-%i", MaxClients);
+		
+		int iConnectedOffset = GetEntSendPropOffs(this.GetEntIndex(), "m_bConnected");
+		if (iConnectedOffset == -1)
+			ThrowError("Unable to retrieve offset %s", "m_bConnected");
+		
+		Address pAddress = this.GetAddress();
+		Address pOffset = view_as<Address>(view_as<int>(pAddress) + iConnectedOffset + iEntIndex * 4);
+		return view_as<bool>(LoadFromAddress(pOffset, NumberType_Int32));
+	}
+	public void SetConnected(CBasePlayer pPlayer, const bool bConnected)
+	{
+		int iEntIndex = pPlayer.GetEntIndex();
+		bool bOutOfBounds = view_as<bool>((iEntIndex > MaxClients) || (iEntIndex < 0));
+		if (bOutOfBounds)
+			ThrowError("Received out of bounds index %d; range is 0-%i", MaxClients);
+		
+		int iConnectedOffset = GetEntSendPropOffs(this.GetEntIndex(), "m_bConnected");
+		if (iConnectedOffset == -1)
+			ThrowError("Unable to retrieve offset %s", "m_bConnected");
+		
+		Address pAddress = this.GetAddress();
+		Address pOffset = view_as<Address>(view_as<int>(pAddress) + iConnectedOffset + iEntIndex * 4);
+		StoreToAddress(pOffset, view_as<int>(bConnected), NumberType_Int32);
+	}
+}
+
 methodmap CFuncLadder < CBaseEntity
 {
 	public CFuncLadder(const int iEntIndex = -1)
@@ -1850,31 +2398,81 @@ methodmap IServerGameDLL
 
 methodmap CTraceRay < Handle
 {
-	public CTraceRay(const float vecPosition[3], const float vecRayType[3], const int iFlags, const RayType rayType, const TraceEntityFilter traceFilter, const any pData)
+	public CTraceRay(const float vecPosition[3], const float vecRayType[3], const int iTraceMask, const RayType eRayType, const TraceEntityFilter fnFilter, const any pData)
 	{
-		return view_as<CTraceRay>(TR_TraceRayFilterEx(vecPosition, vecRayType, iFlags, rayType, traceFilter, pData));
+		return view_as<CTraceRay>(TR_TraceRayFilterEx(vecPosition, vecRayType, iTraceMask, eRayType, fnFilter, pData));
+	}
+
+	public Handle GetHandle()
+	{
+		return view_as<Handle>(this);
+	}
+	public bool StartedSolid()
+	{
+		return TR_StartSolid(this.GetHandle());
 	}
 	public float GetFraction()
 	{
-		return TR_GetFraction(this);
+		return TR_GetFraction(this.GetHandle());
 	}
 	public CBaseEntity GetEntity()
 	{
-		return CBaseEntity(TR_GetEntityIndex(this));
+		return CBaseEntity(TR_GetEntityIndex(this.GetHandle()));
 	}
 }
 
-public bool TraceEntityFilter_IgnoreData(int iEntity, int iMask, any pData)
+public bool TraceEntityFilter_FVisibleAiLosEnabled(int iEntIndex, int iMask, int iThisEntIndex)
 {
-	return (iEntity != pData);
+	// The current check prevents the ray from hitting the caller.
+	// TODO:
+	// Review how to extend the filter to the original implementation.
+	return iEntIndex != iThisEntIndex;
+	//return CBaseEntity(iEntity).GetCollisionGroup() != COLLISION_GROUP_NONE;
 }
 
-public bool TraceEntityFilter_IgnorePlayers(int iEntity, int iMask, any pData)
+public bool TraceEntityFilter_FVisible(int iEntIndex, int iMask, int iThisEntIndex)
 {
-	CBasePlayer pPlayer = CBasePlayer(iEntity);
+	// The current check prevents the ray from hitting the caller.
+	// TODO:
+	// Review how to extend the filter to the original implementation.
+	return iEntIndex != iThisEntIndex;
+	//return CBaseEntity(iEntity).GetCollisionGroup() != COLLISION_GROUP_NONE;
+}
+
+public bool TraceEntityFilter_IgnoreData(int iEntIndex, int iMask, any pData)
+{
+	return (iEntIndex != pData);
+}
+
+public bool TraceEntityFilter_IgnorePlayers(int iEntIndex, int iMask, any pData)
+{
+	CBasePlayer pPlayer = CBasePlayer(iEntIndex);
 	if (pPlayer.IsValid())
 		return false;
-	return (iEntity != pData);
+	return (iEntIndex != pData);
+}
+
+// This function grabs the member offset within a CSound element from the base of the sound entity.
+//
+Address GetSoundPoolPropAddress(CSoundEnt pSoundEnt, const int iSoundIndex, const char[] szProperty)
+{
+	// Obtain the start offset `CSoundEnt::m_SoundPool`
+	int iOffsetPoolStart = FindDataMapInfo(pSoundEnt.GetEntIndex(), "m_SoundPool");
+	if (iOffsetPoolStart == -1)
+		ThrowError("Unable to retrieve offset %s", "m_SoundPool");
+
+	// obtain the offset within `CSound`
+	int iOffset = FindDataMapInfo(pSoundEnt.GetEntIndex(), szProperty);
+	if (iOffset == -1)
+		ThrowError("Unable to retrieve offset %s", szProperty);
+	else
+		iOffset -= iOffsetPoolStart;
+	
+	if (iOffset <= 0)
+		ThrowError("Internal Error: Unable to retrive offset %s", szProperty);
+	
+	// this + offsetof(m_SoundPool[iSoundIndex]) + offsetof(property)
+	return pSoundEnt.GetAddress() + iOffsetPoolStart + iSoundIndex * g_iCSoundSize + iOffset;
 }
 
 stock CUtlVector operator+(CUtlVector oper1, int oper2)

--- a/scripting/include/srccoop/deathnotice.inc
+++ b/scripting/include/srccoop/deathnotice.inc
@@ -6,6 +6,36 @@
 #pragma newdecls required
 #pragma semicolon 1
 
+int g_pDamageFlagList[] =
+{
+	DMG_PLASMA,
+	DMG_SLOWBURN,
+	DMG_RADIATION,
+	DMG_POISON,
+	DMG_NERVEGAS,
+	DMG_ENERGYBEAM,
+	DMG_SONIC,
+	DMG_SHOCK,
+	DMG_BLAST,
+	DMG_BURN,
+	DMG_CRUSH,
+};
+
+char g_pDamageStringList[sizeof(g_pDamageFlagList)][] =
+{
+	"Plasma",
+	"Fire",
+	"Radiation",
+	"Poison",
+	"Nerve Gas",
+	"Laser Beam",
+	"Sonic Shockwave",
+	"Electric Shock",
+	"Explosion",
+	"Fire",
+	"Physics Prop"
+};
+
 enum struct DnTimerData
 {
 	// Weapon display name.
@@ -70,18 +100,39 @@ methodmap DnManager
 
 		HookConVarChange(g_sDnData.m_piNoticeLevel, DeathNotice_OnConVarChangeScKillfeed);
 	}
+	// Clears all data and kicks the bots.
+	//
+	public static void Clear()
+	{
+		DnTimerData sTimerData;
+		g_sDnData.m_sList.Clear();
+		g_sDnData.m_sTimerData = sTimerData;
+		
+		if (g_sDnData.m_pBot1.IsValid())
+		{
+			g_sDnData.m_pBot1.Kick();
+		}
+
+		if (g_sDnData.m_pBot2.IsValid())
+		{
+			g_sDnData.m_pBot2.Kick();
+		}
+	}
 	// Obtains a bot.
 	//
 	public static CBasePlayer GetBot1()
 	{
 		if (g_sDnData.m_piNoticeLevel.IntValue == 2)
 		{
-			if (!g_sDnData.m_pBot1.IsValid())
+			if (GetRealClientCount(true, false, false) > 0)
 			{
-				g_sDnData.m_pBot1 = CBasePlayer(CreateFakeClient("ScBot01"));
-				g_sDnData.m_pBot1.SetTeam(TEAM_SPECTATOR);
+				if (!g_sDnData.m_pBot1.IsValid())
+				{
+					g_sDnData.m_pBot1 = CBasePlayer(CreateFakeClient("ScBot01"));
+					g_sDnData.m_pBot1.SetTeam(TEAM_SPECTATOR);
+				}
+				return g_sDnData.m_pBot1;
 			}
-			return g_sDnData.m_pBot1;
 		}
 		return NULL_CBASEENTITY;
 	}
@@ -91,12 +142,15 @@ methodmap DnManager
 	{
 		if (g_sDnData.m_piNoticeLevel.IntValue == 2)
 		{
-			if (!g_sDnData.m_pBot2.IsValid())
+			if (GetRealClientCount(true, false, false) > 0)
 			{
-				g_sDnData.m_pBot2 = CBasePlayer(CreateFakeClient("ScBot02"));
-				g_sDnData.m_pBot2.SetTeam(TEAM_SPECTATOR);
+				if (!g_sDnData.m_pBot2.IsValid())
+				{
+					g_sDnData.m_pBot2 = CBasePlayer(CreateFakeClient("ScBot02"));
+					g_sDnData.m_pBot2.SetTeam(TEAM_SPECTATOR);
+				}
+				return g_sDnData.m_pBot2;
 			}
-			return g_sDnData.m_pBot2;
 		}
 		return NULL_CBASEENTITY;
 	}
@@ -164,54 +218,15 @@ methodmap DnManager
 	//
 	public static void GetDisplayNameFromDamageForEvent(const int iDamageFlags, const char[] szClassname, char[] szBuffer, const int iMaxLength)
 	{
-		if (iDamageFlags & DMG_PLASMA)
+		for (int i = 0; i < sizeof(g_pDamageFlagList); ++i)
 		{
-			strcopy(szBuffer, iMaxLength, "Plasma");
+			if (iDamageFlags & g_pDamageFlagList[i])
+			{
+				strcopy(szBuffer, iMaxLength, g_pDamageStringList[i]);
+				break;
+			}
 		}
-		else if (iDamageFlags & DMG_SLOWBURN)
-		{
-			strcopy(szBuffer, iMaxLength, "Fire");
-		}
-		else if (iDamageFlags & DMG_RADIATION)
-		{
-			strcopy(szBuffer, iMaxLength, "Radiation");
-		}
-		else if (iDamageFlags & DMG_POISON)
-		{
-			strcopy(szBuffer, iMaxLength, "Poison");
-		}
-		else if (iDamageFlags & DMG_NERVEGAS)
-		{
-			strcopy(szBuffer, iMaxLength, "Nerve Gas");
-		}
-		else if (iDamageFlags & DMG_ENERGYBEAM)
-		{
-			strcopy(szBuffer, iMaxLength, "Laser Beam");
-		}
-		else if (iDamageFlags & DMG_SONIC)
-		{
-			strcopy(szBuffer, iMaxLength, "Sonic Shockwave");
-		}
-		else if (iDamageFlags & DMG_SHOCK)
-		{
-			strcopy(szBuffer, iMaxLength, "Electric Shock");
-		}
-		else if (iDamageFlags & DMG_BLAST)
-		{
-			strcopy(szBuffer, iMaxLength, "Explosion");
-		}
-		else if (iDamageFlags & DMG_BURN)
-		{
-			strcopy(szBuffer, iMaxLength, "Fire");
-		}
-		else if (iDamageFlags & DMG_CRUSH)
-		{
-			strcopy(szBuffer, iMaxLength, "Physics Prop");
-		}
-		else
-		{
-			strcopy(szBuffer, iMaxLength, szClassname);
-		}
+		strcopy(szBuffer, iMaxLength, szClassname);
 	}
 	// Formats the NPC string for a display event.
 	//
@@ -255,11 +270,11 @@ methodmap DnManager
 			char szClassname[MAX_CLASSNAME];
 			pInflictor.GetClassname(szClassname, sizeof(szClassname));
 
-			for (int i = 0; i < sizeof(g_pDnWeaponDisplayList); ++i)
+			for (int i = 0; i < sizeof(g_pDnWeaponIconList); ++i)
 			{
-				if (strcmp(szClassname, g_pDnWeaponDisplayList[i][0], false) == 0)
+				if (strcmp(szClassname, g_pDnWeaponIconList[i][0], false) == 0)
 				{
-					strcopy(szBuffer, iMaxLength, g_pDnWeaponDisplayList[i][1]);
+					strcopy(szBuffer, iMaxLength, g_pDnWeaponIconList[i][1]);
 					return;
 				}
 			}
@@ -313,7 +328,6 @@ methodmap DnManager
 		}
 		return true;
 	}
-	
 	// Entity killed Entity or Player
 	//
 	public static bool WriteEntryEntityKills(DnEntry sEntry, CBaseEntity pAttacker, CBaseEntity pVictim)
@@ -408,7 +422,7 @@ methodmap DnManager
 			// Pushes a entry a new queue if a queue does not exist.
 			// If a queue does exist, pushes a entry to the queue. 
 			g_sDnData.m_sList.PushArray(sEntry, sizeof(sEntry));
-			if (g_sDnData.m_hTimer == INVALID_HANDLE)
+			if (!g_sDnData.m_hTimer)
 			{
 				g_sDnData.m_hTimer = CreateTimer(flDelay, DeathNotice_Timer, _, TIMER_REPEAT);
 			}
@@ -417,17 +431,23 @@ methodmap DnManager
 		{
 			if (sEntry.m_bSuicide)
 			{
-				PrintToChatAll(SRCCOOP_CHAT_TAG..."%s suicided!", sEntry.m_szTarget2Name);
+				// TODO:
+				// Translations.
+				MsgAllNoSrv("%s suicided!", sEntry.m_szTarget2Name);
 			}
 			else
 			{
 				if (strlen(sEntry.m_szWeapon) != 0)
 				{
-					PrintToChatAll(SRCCOOP_CHAT_TAG..."%s killed %s with %s!", sEntry.m_szTarget1Name, sEntry.m_szTarget2Name, sEntry.m_szWeapon);
+					// TODO:
+					// Translations.
+					MsgAllNoSrv("%s killed %s with %s!", sEntry.m_szTarget1Name, sEntry.m_szTarget2Name, sEntry.m_szWeapon);
 				}
 				else
 				{
-					PrintToChatAll(SRCCOOP_CHAT_TAG..."%s killed %s!", sEntry.m_szTarget1Name, sEntry.m_szTarget2Name);
+					// TODO:
+					// Translations.
+					MsgAllNoSrv("%s killed %s!", sEntry.m_szTarget1Name, sEntry.m_szTarget2Name);
 				}
 			}
 		}
@@ -460,17 +480,7 @@ public void DeathNotice_OnConVarChangeScKillfeed(ConVar piConVar, char[] szOldVa
 {
 	if (piConVar.IntValue != 2)
 	{
-		g_sDnData.m_sList.Clear();
-
-		if (g_sDnData.m_pBot1.IsValid())
-		{
-			g_sDnData.m_pBot1.Kick();
-		}
-
-		if (g_sDnData.m_pBot2.IsValid())
-		{
-			g_sDnData.m_pBot2.Kick();
-		}
+		DnManager.Clear();
 	}
 }
 

--- a/scripting/include/srccoop/deathnotice.inc
+++ b/scripting/include/srccoop/deathnotice.inc
@@ -433,7 +433,7 @@ methodmap DnManager
 			{
 				// TODO:
 				// Translations.
-				MsgAllNoSrv("%s suicided!", sEntry.m_szTarget2Name);
+				MsgAllNoSrv("%t", "entity suicided", sEntry.m_szTarget1Name);
 			}
 			else
 			{
@@ -441,13 +441,13 @@ methodmap DnManager
 				{
 					// TODO:
 					// Translations.
-					MsgAllNoSrv("%s killed %s with %s!", sEntry.m_szTarget1Name, sEntry.m_szTarget2Name, sEntry.m_szWeapon);
+					MsgAllNoSrv("%t", "entity killed entity with weapon", sEntry.m_szTarget1Name, sEntry.m_szTarget2Name, sEntry.m_szWeapon);
 				}
 				else
 				{
 					// TODO:
 					// Translations.
-					MsgAllNoSrv("%s killed %s!", sEntry.m_szTarget1Name, sEntry.m_szTarget2Name);
+					MsgAllNoSrv("%t", "entity killed entity", sEntry.m_szTarget1Name, sEntry.m_szTarget2Name);
 				}
 			}
 		}

--- a/scripting/include/srccoop/deathnotice.inc
+++ b/scripting/include/srccoop/deathnotice.inc
@@ -1,0 +1,547 @@
+#if defined _srccoop_deathnotice_included
+ #endinput
+#endif
+#define _srccoop_deathnotice_included
+
+#pragma newdecls required
+#pragma semicolon 1
+
+enum struct DnTimerData
+{
+	// Weapon display name.
+	char m_szWeapon[48];
+	// Attacker.
+	CBasePlayer m_pTarget1;
+	// Victim.
+	CBasePlayer m_pTarget2;
+}
+
+enum struct DnEntry
+{
+	// Weapon display name.
+	char m_szWeapon[48];
+	// Attacker Name.
+	char m_szTarget1Name[MAX_NAME_LENGTH];
+	// Victim Name.
+	char m_szTarget2Name[MAX_NAME_LENGTH];
+	// Attacker.
+	CBasePlayer m_pTarget1;
+	// Victim.
+	CBasePlayer m_pTarget2;
+	// Was this a suicide?
+	bool m_bSuicide;
+}
+
+enum struct DnData
+{
+	// Array of `DnEntry`.
+	ArrayList m_sList;
+	// Bot 1 used for displays when `sc_killfeed` is set to `2`.
+	CBasePlayer m_pBot1;
+	// Bot 2 used for displays when `sc_killfeed` and `sc_killfeed_entity_kills` is set to `2`.
+	CBasePlayer m_pBot2;
+	// Timer used for displays.
+	Handle m_hTimer;
+	// Timer display data.
+	DnTimerData m_sTimerData;
+	// Controls where if the "player_death" event should broadcast.
+	bool m_bBroadcastEnabled;
+	// `sc_killfeed`
+	ConVar m_piNoticeLevel;
+	// `sc_killfeed_player_kills`
+	ConVar m_piNoticePlayerKills;
+	// `sc_killfeed_entity_kills`
+	ConVar m_piNoticeEntityKills;
+	// `sc_killfeed_suicides`
+	ConVar m_piNoticeSuicides;
+}
+
+DnData g_sDnData;
+
+methodmap DnManager
+{
+	public static void Initialize()
+	{
+		g_sDnData.m_sList = new ArrayList(sizeof(DnEntry));
+		g_sDnData.m_piNoticeLevel = CreateConVar("sc_killfeed", "2", "Controls the display of the kill feed (0: disabled, 1: chat, 2: hud). If this Convar is set to `2`, then the plugin will spawn in fake clients to display on the kill feed.", _, true, 0.0, true, 2.0);
+		g_sDnData.m_piNoticePlayerKills = CreateConVar("sc_killfeed_player_kills", "2", "Controls display of player kills on the kill feed (0: hide, 1: players, 2: entities).", _, true, 0.0, true, 2.0);
+		g_sDnData.m_piNoticeEntityKills = CreateConVar("sc_killfeed_entity_kills", "2", "Controls display of entity kills on the kill feed (0: hide, 1: players, 2: entities).", _, true, 0.0, true, 2.0);
+		g_sDnData.m_piNoticeSuicides = CreateConVar("sc_killfeed_suicides", "2", "Controls display of suicides on the kill feed (0: hide, 1: players, 2: entities).", _, true, 0.0, true, 2.0);
+
+		HookConVarChange(g_sDnData.m_piNoticeLevel, DeathNotice_OnConVarChangeScKillfeed);
+	}
+	// Obtains a bot.
+	//
+	public static CBasePlayer GetBot1()
+	{
+		if (g_sDnData.m_piNoticeLevel.IntValue == 2)
+		{
+			if (!g_sDnData.m_pBot1.IsValid())
+			{
+				g_sDnData.m_pBot1 = CBasePlayer(CreateFakeClient("ScBot01"));
+				g_sDnData.m_pBot1.SetTeam(TEAM_SPECTATOR);
+			}
+			return g_sDnData.m_pBot1;
+		}
+		return NULL_CBASEENTITY;
+	}
+	// Obtains a bot.
+	//
+	public static CBasePlayer GetBot2()
+	{
+		if (g_sDnData.m_piNoticeLevel.IntValue == 2)
+		{
+			if (!g_sDnData.m_pBot2.IsValid())
+			{
+				g_sDnData.m_pBot2 = CBasePlayer(CreateFakeClient("ScBot02"));
+				g_sDnData.m_pBot2.SetTeam(TEAM_SPECTATOR);
+			}
+			return g_sDnData.m_pBot2;
+		}
+		return NULL_CBASEENTITY;
+	}
+	// Hook callback to hide player name changes for bots.
+	// Bots have to change their names in order to display a death display.
+	//
+	public static Action TextMsg(BfRead bf)
+    {
+		if (!CoopManager.IsCoopModeEnabled() || g_sDnData.m_piNoticeLevel.IntValue == 0)
+			return Plugin_Continue;
+
+		bf.ReadByte();
+		char szMessage[96];
+		bf.ReadString(szMessage, sizeof(szMessage));
+
+		// TODO:
+		// This currently works for Black Mesa.
+		//
+		// - Does this work for HL2DM?
+		// - Logic should be implemented for blocking only when a death notice bot is changing their name.
+		//
+		if (StrContains(szMessage, "changed name to") != -1)
+		{
+			return Plugin_Stop;
+    	}
+
+		return Plugin_Continue;
+	}
+	// Hook callback to hide the player death displays unless this plugin's features are enabled.
+	//
+	public static Action PlayerDeath(Event hEvent)
+    {
+		if (!CoopManager.IsCoopModeEnabled())
+			return Plugin_Continue;
+
+		if (g_sDnData.m_piNoticeLevel.IntValue == 0)
+			return Plugin_Continue;
+
+		return g_sDnData.m_bBroadcastEnabled ? Plugin_Continue : Plugin_Stop;
+	}
+	// Checks whether if a entity should be allowed to display as a notification.
+	// This is reserved for entities that would not make sense being displayed.
+	//
+	public static bool IsEntityAllowed(CBaseEntity pEntity)
+	{
+		char szClassname[MAX_CLASSNAME];
+		pEntity.GetClassname(szClassname, sizeof(szClassname));
+		return strcmp(szClassname, "npc_bullseye", false) != 0;
+	}
+	// Handles changing the death notice bot names
+	//
+	public static bool HandleDisplayName(CBasePlayer pPlayer, const char[] szName)
+	{
+		// Changes the player name if it is a bot handled by the manager.
+		// This is used for the display of a entity on death notices.
+		if (pPlayer.IsValid())
+		{
+			if (pPlayer == g_sDnData.m_pBot1 || pPlayer == g_sDnData.m_pBot2)
+			{
+				pPlayer.SetName(szName);
+			}
+		}
+	}
+	// Formats damage flags for a display event.
+	//
+	public static void GetDisplayNameFromDamageForEvent(const int iDamageFlags, const char[] szClassname, char[] szBuffer, const int iMaxLength)
+	{
+		if (iDamageFlags & DMG_PLASMA)
+		{
+			strcopy(szBuffer, iMaxLength, "Plasma");
+		}
+		else if (iDamageFlags & DMG_SLOWBURN)
+		{
+			strcopy(szBuffer, iMaxLength, "Fire");
+		}
+		else if (iDamageFlags & DMG_RADIATION)
+		{
+			strcopy(szBuffer, iMaxLength, "Radiation");
+		}
+		else if (iDamageFlags & DMG_POISON)
+		{
+			strcopy(szBuffer, iMaxLength, "Poison");
+		}
+		else if (iDamageFlags & DMG_NERVEGAS)
+		{
+			strcopy(szBuffer, iMaxLength, "Nerve Gas");
+		}
+		else if (iDamageFlags & DMG_ENERGYBEAM)
+		{
+			strcopy(szBuffer, iMaxLength, "Laser Beam");
+		}
+		else if (iDamageFlags & DMG_SONIC)
+		{
+			strcopy(szBuffer, iMaxLength, "Sonic Shockwave");
+		}
+		else if (iDamageFlags & DMG_SHOCK)
+		{
+			strcopy(szBuffer, iMaxLength, "Electric Shock");
+		}
+		else if (iDamageFlags & DMG_BLAST)
+		{
+			strcopy(szBuffer, iMaxLength, "Explosion");
+		}
+		else if (iDamageFlags & DMG_BURN)
+		{
+			strcopy(szBuffer, iMaxLength, "Fire");
+		}
+		else if (iDamageFlags & DMG_CRUSH)
+		{
+			strcopy(szBuffer, iMaxLength, "Physics Prop");
+		}
+		else
+		{
+			strcopy(szBuffer, iMaxLength, szClassname);
+		}
+	}
+	// Formats the NPC string for a display event.
+	//
+	public static void GetDisplayNameForEvent(CBaseEntity pEntity, char[] szBuffer, const int iMaxLength)
+	{
+		char szClassname[MAX_CLASSNAME];
+		pEntity.GetClassname(szClassname, sizeof(szClassname));
+
+		// TODO:
+		// Handle damage flags for `func_movelinear`/`func_tracktrain`. 
+		if (strcmp(szClassname, "point_hurt", false) == 0)
+		{
+			int iDamageFlags = view_as<CPointHurt>(pEntity).GetDamageType();
+			DnManager.GetDisplayNameFromDamageForEvent(iDamageFlags, szClassname, szBuffer, iMaxLength);
+		}
+		else if (strcmp(szClassname, "trigger_hurt", false) == 0)
+		{
+			int iDamageFlags = view_as<CTriggerHurt>(pEntity).GetDamageType();
+			DnManager.GetDisplayNameFromDamageForEvent(iDamageFlags, szClassname, szBuffer, iMaxLength);
+		}
+		else
+		{
+			for (int i = 0; i < sizeof(g_pDnDisplayList); ++i)
+			{
+				if (strcmp(szClassname, g_pDnDisplayList[i][0], false) == 0)
+				{
+					strcopy(szBuffer, iMaxLength, g_pDnDisplayList[i][1]);
+					return;
+				}
+			}
+
+			strcopy(szBuffer, iMaxLength, szClassname);
+		}
+	}
+	// Formats the weapon string for a display event.
+	//
+	public static void GetWeaponNameForEvent(CBaseEntity pInflictor, char[] szBuffer, const int iMaxLength)
+	{
+		if (pInflictor.IsValid())
+		{
+			char szClassname[MAX_CLASSNAME];
+			pInflictor.GetClassname(szClassname, sizeof(szClassname));
+
+			for (int i = 0; i < sizeof(g_pDnWeaponDisplayList); ++i)
+			{
+				if (strcmp(szClassname, g_pDnWeaponDisplayList[i][0], false) == 0)
+				{
+					strcopy(szBuffer, iMaxLength, g_pDnWeaponDisplayList[i][1]);
+					return;
+				}
+			}
+		}
+		strcopy(szBuffer, iMaxLength, "");
+	}
+	// Player killed Player or Entity
+	//
+	public static bool WriteEntryPlayerKill(DnEntry sEntry, CBasePlayer pAttacker, CBaseEntity pVictim)
+	{
+		sEntry.m_pTarget1 = pAttacker;
+		sEntry.m_pTarget1.GetName(sEntry.m_szTarget1Name, sizeof(sEntry.m_szTarget1Name));
+
+		if (pVictim.IsClassPlayer())
+		{
+			if (pAttacker == pVictim)
+			{
+				// Check if player suicides is enabled.
+				if (g_sDnData.m_piNoticeSuicides.IntValue < 1)
+					return false;
+
+				sEntry.m_pTarget2 = sEntry.m_pTarget1;
+				sEntry.m_szTarget2Name = sEntry.m_szTarget1Name;
+				sEntry.m_bSuicide = true;
+			}
+			else
+			{
+				// Check if player killing players is enabled.
+				if (g_sDnData.m_piNoticePlayerKills.IntValue == 0)
+					return false;
+				
+				// The victim is a player so it can be used directly.
+				sEntry.m_pTarget2 = view_as<CBasePlayer>(pVictim);
+				sEntry.m_pTarget2.GetName(sEntry.m_szTarget2Name, sizeof(sEntry.m_szTarget2Name));
+				sEntry.m_bSuicide = false;
+			}
+		}
+		else
+		{
+			// Check if player killing entities is enabled.
+			if (g_sDnData.m_piNoticePlayerKills.IntValue != 2)
+				return false;
+
+			// The victim is a entity so a bot will have to be used.
+			sEntry.m_pTarget2 = DnManager.GetBot1();
+			if (g_sDnData.m_piNoticeLevel.IntValue == 2 && !sEntry.m_pTarget2.IsValid())
+				return false;
+				
+			DnManager.GetDisplayNameForEvent(pVictim, sEntry.m_szTarget2Name, sizeof(sEntry.m_szTarget2Name));
+			sEntry.m_bSuicide = false;
+		}
+		return true;
+	}
+	
+	// Entity killed Entity or Player
+	//
+	public static bool WriteEntryEntityKills(DnEntry sEntry, CBaseEntity pAttacker, CBaseEntity pVictim)
+	{
+		// TODO:
+		// Should this be moved further down? This bot will always be created if `sc_killfeed` is set to `2`.
+		sEntry.m_pTarget1 = DnManager.GetBot1();
+		// pTarget1 will be NULL unless the notice level is set to 2.
+		if (g_sDnData.m_piNoticeLevel.IntValue == 2 && !sEntry.m_pTarget1.IsValid())
+			return false;
+		DnManager.GetDisplayNameForEvent(pAttacker, sEntry.m_szTarget1Name, sizeof(sEntry.m_szTarget1Name));
+
+		if (pVictim.IsClassPlayer())
+		{
+			// Check if feature is enabled.
+			if (g_sDnData.m_piNoticeEntityKills.IntValue == 0)
+				return false;
+
+			// The victim is a player so it can be used directly.
+			sEntry.m_pTarget2 = view_as<CBasePlayer>(pVictim);
+			sEntry.m_pTarget2.GetName(sEntry.m_szTarget2Name, sizeof(sEntry.m_szTarget2Name));
+			sEntry.m_bSuicide = false;
+		}
+		else
+		{
+			if (pAttacker == pVictim)
+			{
+				// Check if entity suicides is enabled.
+				if (g_sDnData.m_piNoticeSuicides.IntValue < 2)
+					return false;
+				
+				sEntry.m_pTarget2 = sEntry.m_pTarget1;
+				sEntry.m_szTarget2Name = sEntry.m_szTarget1Name;
+				sEntry.m_bSuicide = true;
+			}
+			else
+			{
+				// Check if entities killing entities is enabled.
+				if (g_sDnData.m_piNoticeEntityKills.IntValue != 2)
+					return false;
+
+				// The victim is a entity so a bot will have to be used.
+				sEntry.m_pTarget2 = DnManager.GetBot2();
+				if (g_sDnData.m_piNoticeLevel.IntValue == 2 && !sEntry.m_pTarget2.IsValid())
+					return false;
+				
+				DnManager.GetDisplayNameForEvent(pVictim, sEntry.m_szTarget2Name, sizeof(sEntry.m_szTarget2Name));
+				sEntry.m_bSuicide = false;
+			}
+		}
+		return true;
+	}
+	// Hook callback that detects and handles player and entity kills.
+	//
+	public static void EntityKilled(Event hEvent)
+	{
+		if (!CoopManager.IsCoopModeEnabled())
+    	    return;
+
+		CBaseEntity pAttacker = CBaseEntity(hEvent.GetInt("entindex_attacker"));
+		CBaseEntity pVictim = CBaseEntity(hEvent.GetInt("entindex_killed"));
+		CBaseEntity pInflictor = CBaseEntity(hEvent.GetInt("entindex_inflictor"));
+
+		if (!pAttacker.IsValid() || !pVictim.IsValid() || !DnManager.IsEntityAllowed(pVictim))
+			return;
+		
+		DnEntry sEntry;
+		if (pAttacker.IsClassPlayer())
+		{
+			if (!DnManager.WriteEntryPlayerKill(sEntry, view_as<CBasePlayer>(pAttacker), pVictim))
+				return;
+		}
+		else
+		{
+			if (!DnManager.WriteEntryEntityKills(sEntry, pAttacker, pVictim))
+				return;
+		}
+		DnManager.GetWeaponNameForEvent(pInflictor, sEntry.m_szWeapon, sizeof(sEntry.m_szWeapon));
+		DnManager.PushDeathNotice(sEntry);
+	}
+	// Pushes a death notice entry onto the display.
+	//
+	public static void PushDeathNotice(DnEntry sEntry)
+	{
+		if (g_sDnData.m_piNoticeLevel.IntValue == 2)
+		{
+			// Delay is used to allow time for the game to update the player name.
+			// If the death notification displays before the player name is
+			// updated, then the old name will be displayed which is unintended behavior.
+			float flDelay = 0.35; 
+
+			// Pushes a entry a new queue if a queue does not exist.
+			// If a queue does exist, pushes a entry to the queue. 
+			g_sDnData.m_sList.PushArray(sEntry, sizeof(sEntry));
+			if (g_sDnData.m_hTimer == INVALID_HANDLE)
+			{
+				g_sDnData.m_hTimer = CreateTimer(flDelay, DeathNotice_Timer, _, TIMER_REPEAT);
+			}
+		}
+		else if (g_sDnData.m_piNoticeLevel.IntValue == 1)
+		{
+			if (sEntry.m_bSuicide)
+			{
+				PrintToChatAll(SRCCOOP_CHAT_TAG..."%s suicided!", sEntry.m_szTarget2Name);
+			}
+			else
+			{
+				if (strlen(sEntry.m_szWeapon) != 0)
+				{
+					PrintToChatAll(SRCCOOP_CHAT_TAG..."%s killed %s with %s!", sEntry.m_szTarget1Name, sEntry.m_szTarget2Name, sEntry.m_szWeapon);
+				}
+				else
+				{
+					PrintToChatAll(SRCCOOP_CHAT_TAG..."%s killed %s!", sEntry.m_szTarget1Name, sEntry.m_szTarget2Name);
+				}
+			}
+		}
+	}
+	// Sends a "player_death" event to the client without being blocked.
+	//
+	public static void DrawNoticeIngame(CBasePlayer pAttacker, CBasePlayer pVictim, const char[] szWeapon)
+	{
+		// The "player_death" event is hooked so the game's normal
+		// death notifications do not appear. The broadcasting
+		// of the event is temporarily enabled so that this function
+		// can send it.
+
+		// Enable broadcasting temporarily for a single "player_death" event to send.
+		g_sDnData.m_bBroadcastEnabled = true;
+
+		// this displays a death notice ingame
+		Event hEvent = CreateEvent("player_death");
+		hEvent.SetString("weapon", szWeapon);
+		hEvent.SetInt("attacker", pAttacker.GetUserId());
+		hEvent.SetInt("userid", pVictim.GetUserId());
+		hEvent.Fire();
+
+		// Disable broadcast to disallow the "player_death" event from being sent.
+		g_sDnData.m_bBroadcastEnabled = false;
+	}
+}
+
+public void DeathNotice_OnConVarChangeScKillfeed(ConVar piConVar, char[] szOldValue, char[] szNewValue)
+{
+	if (piConVar.IntValue != 2)
+	{
+		g_sDnData.m_sList.Clear();
+
+		if (g_sDnData.m_pBot1.IsValid())
+		{
+			g_sDnData.m_pBot1.Kick();
+		}
+
+		if (g_sDnData.m_pBot2.IsValid())
+		{
+			g_sDnData.m_pBot2.Kick();
+		}
+	}
+}
+
+// Draws a notice with a delay between each display. 
+// The delay is used to allow time for the game to update the player name.
+// If the death notification displays before the player name is
+// updated, then the old name will be displayed which is unintended behavior.
+//
+public Action DeathNotice_Timer(Handle hTimer)
+{
+	// If the timer just started, this won't call immediately.
+	if (g_sDnData.m_sTimerData.m_pTarget1.IsValid() && g_sDnData.m_sTimerData.m_pTarget2.IsValid())
+	{
+		DnManager.DrawNoticeIngame(g_sDnData.m_sTimerData.m_pTarget1, g_sDnData.m_sTimerData.m_pTarget2, g_sDnData.m_sTimerData.m_szWeapon);
+	}
+
+	// Consume a entry.
+	if (g_sDnData.m_sList.Length > 0)
+	{
+		// Get entry.
+		DnEntry sEntry;
+		g_sDnData.m_sList.GetArray(0, sEntry, sizeof(sEntry));
+		
+		// Assign the current entry to the timer.
+		g_sDnData.m_sTimerData.m_szWeapon = sEntry.m_szWeapon;
+		g_sDnData.m_sTimerData.m_pTarget1 = sEntry.m_pTarget1;
+		g_sDnData.m_sTimerData.m_pTarget2 = sEntry.m_pTarget2;
+
+		// Change the player's name if it is death notice bot.
+		DnManager.HandleDisplayName(g_sDnData.m_sTimerData.m_pTarget1, sEntry.m_szTarget1Name);
+		if (g_sDnData.m_sTimerData.m_pTarget1 != g_sDnData.m_sTimerData.m_pTarget2)
+		{
+			// This is formatted to avoid a naming conflict with the first bot.
+			char szTarget2Name[MAX_NAME_LENGTH];
+			Format(szTarget2Name, sizeof(szTarget2Name), "%s ", sEntry.m_szTarget2Name);
+			DnManager.HandleDisplayName(g_sDnData.m_sTimerData.m_pTarget2, szTarget2Name);
+		}
+
+		// Remove the current entry.
+		g_sDnData.m_sList.Erase(0);
+
+		return Plugin_Continue;
+	}
+	else
+	{
+		// Destroy timer.
+		DnTimerData sTimerData;
+		g_sDnData.m_hTimer = INVALID_HANDLE;
+		g_sDnData.m_sTimerData = sTimerData;
+		return Plugin_Stop;
+	}
+}
+
+//public Action Event_LogicAchievementOnFired(const char[] szOutput, int iCaller, int iActivator, float flDelay)
+//{
+//	//PrintToChatAll(SRCCOOP_CHAT_TAG..."Server has earned the achievement \x03%s", "#BMS_BROWN_MOTION_NAME");
+//
+//	if (CoopManager.IsCoopModeEnabled())
+//	{
+//		char szAchievement[96];
+//		CLogicAchievement(iCaller).GetAchievementEventID(szAchievement, sizeof(szAchievement));
+//		if (strncmp(szAchievement, ACHIEVEMENT_PREFIX, strlen(ACHIEVEMENT_PREFIX)) == 0)
+//		{
+//			// broadcast achievement ui element to every player
+//			Event hAchievementEvent = CreateEvent("achievement_event");
+//			hAchievementEvent.SetString("achievement_name", szAchievement[strlen(ACHIEVEMENT_PREFIX)]);
+//			hAchievementEvent.SetInt("cur_val", 1);
+//			hAchievementEvent.SetInt("max_val", 1);
+//			hAchievementEvent.Fire();
+//		}
+//	}
+//
+//	return Plugin_Continue;
+//}

--- a/scripting/include/srccoop/entitypatch.inc
+++ b/scripting/include/srccoop/entitypatch.inc
@@ -29,6 +29,36 @@ void ClearLocalPlayerCallingEntity()
 	g_pLocalPlayerEntity = NULL_CBASEENTITY;
 }
 
+public bool HasAnyPlayerWalkedIntoWakeRadius(CAI_BaseNPC pBaseNPC)
+{
+	float flWakeRadius = pBaseNPC.GetWakeRadius();
+	bool bHasBigEnoughRadius = flWakeRadius > 0.1;
+	if (!bHasBigEnoughRadius)
+	{
+		return false;
+	}
+
+	float vec3EntityPosition[3];
+	pBaseNPC.GetAbsOrigin(vec3EntityPosition);
+
+	for (int i = 1; i <= MaxClients; ++i)
+	{
+		CBasePlayer pPlayer = CBasePlayer(i);
+		if (pPlayer.IsValid() && pPlayer.IsAlive() && !(pPlayer.GetFlags() & FL_NOTARGET))
+		{
+			float vec3PlayerPosition[3];
+			pPlayer.GetAbsOrigin(vec3PlayerPosition);
+
+			if (GetVectorDistance(vec3EntityPosition, vec3PlayerPosition) <= flWakeRadius)
+			{
+				return true;
+			}
+		}
+	}
+
+	return false;
+}
+
 //------------------------------------------------------
 // UTIL_GetLocalPlayer
 //------------------------------------------------------
@@ -908,12 +938,118 @@ public MRESReturn Hook_SetPlayerAvoidState(int _this)
 	return MRES_Supercede;
 }
 
-//------------------------------------------------------
-// CProtoSniper - npc_sniper
-// Crashed in AI_GetSinglePlayer nullptr
-// This function is remade from scratch
-//------------------------------------------------------
-public MRESReturn Hook_ProtoSniperSelectSchedule(int _this, Handle hReturn)	// https://github.com/ValveSoftware/source-sdk-2013/blob/0d8dceea4310fde5706b3ce1c70609d72a38efdf/mp/src/game/server/hl2/proto_sniper.cpp#L1385
+// `UpdateSleepState` ends early due to a null pointer check for the local player.
+// The entire function is reconstructed to remove the check and to support multiple players.
+// 
+// Class: `CAI_BaseNPC`
+//
+// ## Citations
+//
+// - [Source SDK 2013](https://github.com/ValveSoftware/source-sdk-2013/blob/0d8dceea4310fde5706b3ce1c70609d72a38efdf/mp/src/game/server/ai_basenpc.cpp#L3353)
+//
+public MRESReturn Hook_BaseNpcUpdateSleepState(int _this, Handle hParams)
+{
+	// TODO: does bInPVS work for any and all players?
+	CAI_BaseNPC pBaseNPC = CAI_BaseNPC(_this);
+	bool bInPVS = DHookGetParam(hParams, 1);
+	
+	int iSleepState = pBaseNPC.GetSleepState();
+	if (iSleepState > view_as<int>(AISS_AWAKE))
+	{
+		// wake up if any player has walked into radius
+		if (HasAnyPlayerWalkedIntoWakeRadius(pBaseNPC))
+		{
+			pBaseNPC.Wake();
+		}
+		else if (iSleepState == view_as<int>(AISS_WAITING_FOR_PVS))
+		{
+			if (bInPVS)
+			{
+				pBaseNPC.Wake();
+			}
+		}
+		else if (iSleepState == view_as<int>(AISS_WAITING_FOR_THREAT))
+		{
+			if (pBaseNPC.HasCondition(view_as<int>(COND_LIGHT_DAMAGE)) || pBaseNPC.HasCondition(view_as<int>(COND_HEAVY_DAMAGE)))
+			{
+				pBaseNPC.Wake();
+			}
+			else
+			{
+				if (bInPVS)
+				{
+					for (int i = 1; i <= MaxClients; ++i)
+					{
+						// TODO:
+						// Should this check for if the player is alive?
+						CBasePlayer pPlayer = CBasePlayer(i);
+						if (pPlayer.IsValid() && pPlayer.IsAlive() && !(pPlayer.GetFlags() & FL_NOTARGET) && pPlayer.FVisibleEntity(pBaseNPC))
+						{
+							pBaseNPC.Wake();
+							break;
+						}
+					}
+				}
+				
+				if ((pBaseNPC.GetSoundInterests() & SOUND_DANGER) && !(pBaseNPC.HasSpawnFlag(SF_NPC_WAIT_TILL_SEEN)))
+				{
+					CSoundEnt pSoundEnt = CSoundEnt(FindEntityByClassname(-1, "soundent"));
+					if (pSoundEnt.IsValid())
+					{
+						CSound pSound;
+						pSoundEnt.ActiveList(pSound);
+						for (; pSound.IsValid(); pSound.Next())
+						{
+							if ((pSound.GetType() & SOUND_DANGER) && pBaseNPC.CanHearSound(pSound) && pBaseNPC.IsSoundVisible(pSound))
+							{
+								pBaseNPC.Wake();
+								break;
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+	else
+	{
+		// NPC is awake
+		// Don't let an NPC sleep if they're running a script!
+		if (!pBaseNPC.IsInAScript() && pBaseNPC.GetState() != view_as<int>(NPC_STATE_SCRIPT))
+		{
+			if (pBaseNPC.HasSleepFlags(AI_SLEEP_FLAG_AUTO_PVS))
+			{
+				if (!pBaseNPC.HasCondition(view_as<int>(COND_IN_PVS)))
+				{
+					pBaseNPC.SetSleepState(view_as<int>(AISS_WAITING_FOR_PVS));
+					pBaseNPC.Sleep();
+				}
+			}
+
+			if (pBaseNPC.HasSleepFlags(AI_SLEEP_FLAG_AUTO_PVS_AFTER_PVS))
+			{
+				if (pBaseNPC.HasCondition(view_as<int>(COND_IN_PVS)))
+				{
+					// OK, we're in the player's PVS. Now switch to regular old AUTO_PVS sleep rules.
+					pBaseNPC.AddSleepFlags(view_as<int>(AI_SLEEP_FLAG_AUTO_PVS));
+					pBaseNPC.RemoveSleepFlags(view_as<int>(AI_SLEEP_FLAG_AUTO_PVS_AFTER_PVS));
+				}
+			}
+		}
+	}
+
+	return MRES_Supercede;
+}
+
+// `SelectSchedule` crashes because a null local player pointer was accessed.
+// The entire function is reconstructed to remove the check.
+// 
+// Class: `CProtoSniper` - npc_sniper
+//
+// ## Citations
+// - [Source SDK 2013](https://github.com/ValveSoftware/source-sdk-2013/blob/0d8dceea4310fde5706b3ce1c70609d72a38efdf/mp/src/game/server/hl2/proto_sniper.cpp#L1385)
+//
+public MRESReturn Hook_ProtoSniperSelectSchedule(int _this, Handle hReturn)
 {
 	CProtoSniper pSniper = CProtoSniper(_this);
 	

--- a/scripting/include/srccoop/entitypatch.inc
+++ b/scripting/include/srccoop/entitypatch.inc
@@ -980,8 +980,6 @@ public MRESReturn Hook_BaseNpcUpdateSleepState(int _this, Handle hParams)
 				{
 					for (int i = 1; i <= MaxClients; ++i)
 					{
-						// TODO:
-						// Should this check for if the player is alive?
 						CBasePlayer pPlayer = CBasePlayer(i);
 						if (pPlayer.IsValid() && pPlayer.IsAlive() && !(pPlayer.GetFlags() & FL_NOTARGET) && pPlayer.FVisibleEntity(pBaseNPC))
 						{

--- a/scripting/include/srccoop/globals.inc
+++ b/scripting/include/srccoop/globals.inc
@@ -135,6 +135,10 @@ DynamicDetour hkPickup_ForcePlayerToDropThisObject;
 DynamicDetour hkSetPlayerAvoidState;
 #endif
 
+#if defined ENTPATCH_NPC_SLEEP
+DynamicDetour hkBaseNpcUpdateSleepState;
+#endif
+
 #if defined SRCCOOP_HL2DM && defined PLAYERPATCH_SERVERSIDE_RAGDOLLS
 DynamicHook hkCreateRagdollEntity;
 #endif

--- a/scripting/include/srccoop/hl2dm/deathnotice.inc
+++ b/scripting/include/srccoop/hl2dm/deathnotice.inc
@@ -6,6 +6,12 @@
 #pragma newdecls required
 #pragma semicolon 1
 
-char g_pDnDisplayList[][2][];
+char g_pDnDisplayList[][2][] =
+{
+    { "npc_combine_s", "Combine Soldier" },
+};
 
-char g_pDnWeaponDisplayList[][2][];
+char g_pDnWeaponDisplayList[][2][] =
+{
+    { "weapon_ar2", "ar2" },
+};

--- a/scripting/include/srccoop/hl2dm/deathnotice.inc
+++ b/scripting/include/srccoop/hl2dm/deathnotice.inc
@@ -1,0 +1,11 @@
+#if defined _srccoop_deathnotice_game_included
+ #endinput
+#endif
+#define _srccoop_deathnotice_game_included
+
+#pragma newdecls required
+#pragma semicolon 1
+
+char g_pDnDisplayList[][2][];
+
+char g_pDnWeaponDisplayList[][2][];

--- a/scripting/include/srccoop/hl2dm/deathnotice.inc
+++ b/scripting/include/srccoop/hl2dm/deathnotice.inc
@@ -11,7 +11,7 @@ char g_pDnDisplayList[][2][] =
     { "npc_combine_s", "Combine Soldier" },
 };
 
-char g_pDnWeaponDisplayList[][2][] =
+char g_pDnWeaponIconList[][2][] =
 {
     { "weapon_ar2", "ar2" },
 };

--- a/scripting/include/srccoop/typedef_game.inc
+++ b/scripting/include/srccoop/typedef_game.inc
@@ -15,6 +15,8 @@
 #define MAX_MAPNAME 32
 #define MAX_CLASSNAME 48
 
+#define ACHIEVEMENT_PREFIX "ACHIEVEMENT_EVENT_"
+
 #define vec3_origin {0.0, 0.0, 0.0}
 
 #define VEC_HULL_MIN {-16.0, -16.0, 0.0}
@@ -28,6 +30,24 @@
 #define TIME_TO_TICKS(%1)		(RoundToFloor(0.5 + (%1) / TICK_INTERVAL))
 #define TICKS_TO_TIME(%1)		( TICK_INTERVAL *(%1) )
 #define ROUND_TO_TICKS(%1)		( TICK_INTERVAL * TIME_TO_TICKS(%1) )
+
+#define AI_SLEEP_FLAGS_NONE					0x00000000
+#define AI_SLEEP_FLAG_AUTO_PVS				0x00000001
+#define AI_SLEEP_FLAG_AUTO_PVS_AFTER_PVS	0x00000002
+
+
+// -----------------------------------------------------
+// spatial content masks - used for spatial queries (traceline,etc.)
+// -----------------------------------------------------
+
+#define	CONTENTS_BLOCKLOS		0x40	// block AI line of sight
+
+// everything that blocks line of sight for AI
+#define MASK_BLOCKLOS				(CONTENTS_SOLID|CONTENTS_MOVEABLE|CONTENTS_BLOCKLOS)
+// everything that blocks line of sight for AI plus NPCs
+#define MASK_BLOCKLOS_AND_NPCS		(MASK_BLOCKLOS|CONTENTS_MONSTER)
+
+
 
 //------------------------------------------------------
 // Spawnflags
@@ -109,6 +129,23 @@ enum
 #define SF_SPRITE_STARTON		0x0001
 #define SF_SPRITE_ONCE			0x0002
 #define SF_SPRITE_TEMPORARY		0x8000
+
+// NPC spawnflags
+#define SF_NPC_WAIT_TILL_SEEN			( 1 << 0  )	// spawnflag that makes npcs wait until player can see them before attacking.
+#define SF_NPC_GAG						( 1 << 1  )	// no idle noises from this npc
+#define SF_NPC_FALL_TO_GROUND			( 1 << 2  )	// used my NPC_Maker
+#define SF_NPC_DROP_HEALTHKIT			( 1 << 3  )	// Drop a healthkit upon death
+#define SF_NPC_START_EFFICIENT			( 1 << 4  ) // Set into efficiency mode from spawn
+//										( 1 << 5  )
+//										( 1 << 6  )
+#define SF_NPC_WAIT_FOR_SCRIPT			( 1 << 7  )	// spawnflag that makes npcs wait to check for attacking until the script is done or they've been attacked
+#define SF_NPC_LONG_RANGE				( 1 << 8  )	// makes npcs look far and relaxes weapon range limit 
+#define SF_NPC_FADE_CORPSE				( 1 << 9  )	// Fade out corpse after death
+#define SF_NPC_ALWAYSTHINK				( 1 << 10 )	// Simulate even when player isn't in PVS.
+#define SF_NPC_TEMPLATE					( 1 << 11 )	// This NPC will be used as a template by an npc_maker -- do not spawn.
+#define SF_NPC_ALTCOLLISION				( 1 << 12 )
+#define SF_NPC_NO_WEAPON_DROP			( 1 << 13 )	// This NPC will not actually drop a weapon that can be picked up
+#define SF_NPC_NO_PLAYER_PUSHAWAY		( 1 << 14 )	
 
 //------------------------------------------------------
 // Effects flags
@@ -3028,3 +3065,69 @@ enum
 	ACT_MP_PUSH_SWIM_SECONDARY,
 	ACT_CACTUS_FLINCH
 }
+
+enum
+{
+	MAX_WORLD_SOUNDS_SP	= 64,	// Maximum number of sounds handled by the world at one time in single player.
+	// This is also the number of entries saved in a savegame file (for b/w compatibility).
+
+	MAX_WORLD_SOUNDS_MP	= 128	// The sound array size is set this large but we'll only use gpGlobals->maxPlayers+32 entries in mp.
+};
+
+enum
+{
+	SOUND_NONE				= 0,
+	SOUND_COMBAT			= 0x00000001,
+	SOUND_WORLD				= 0x00000002,
+	SOUND_PLAYER			= 0x00000004,
+	SOUND_DANGER			= 0x00000008,
+	SOUND_BULLET_IMPACT		= 0x00000010,
+	SOUND_CARCASS			= 0x00000020,
+	SOUND_MEAT				= 0x00000040,
+	SOUND_GARBAGE			= 0x00000080,
+	SOUND_THUMPER			= 0x00000100, // keeps certain creatures at bay
+	SOUND_BUGBAIT			= 0x00000200, // gets the antlion's attention
+	SOUND_PHYSICS_DANGER	= 0x00000400,
+	SOUND_DANGER_SNIPERONLY	= 0x00000800, // only scares the sniper NPC.
+	SOUND_MOVE_AWAY			= 0x00001000,
+	SOUND_PLAYER_VEHICLE	= 0x00002000,
+	SOUND_READINESS_LOW		= 0x00004000, // Changes listener's readiness (Player Companion only)
+	SOUND_READINESS_MEDIUM	= 0x00008000,
+	SOUND_READINESS_HIGH	= 0x00010000,
+
+	// Contexts begin here.
+	SOUND_CONTEXT_FROM_SNIPER		= 0x00100000, // additional context for SOUND_DANGER
+	SOUND_CONTEXT_GUNFIRE			= 0x00200000, // Added to SOUND_COMBAT
+	SOUND_CONTEXT_MORTAR			= 0x00400000, // Explosion going to happen here.
+	SOUND_CONTEXT_COMBINE_ONLY		= 0x00800000, // Only combine can hear sounds marked this way
+	SOUND_CONTEXT_REACT_TO_SOURCE	= 0x01000000, // React to sound source's origin, not sound's location
+	SOUND_CONTEXT_EXPLOSION			= 0x02000000, // Context added to SOUND_COMBAT, usually.
+	SOUND_CONTEXT_EXCLUDE_COMBINE	= 0x04000000, // Combine do NOT hear this
+	SOUND_CONTEXT_DANGER_APPROACH   = 0x08000000, // Treat as a normal danger sound if you see the source, otherwise turn to face source.
+	SOUND_CONTEXT_ALLIES_ONLY		= 0x10000000, // Only player allies can hear this sound
+	SOUND_CONTEXT_PLAYER_VEHICLE	= 0x20000000, // HACK: need this because we're not treating the SOUND_xxx values as true bit values! See switch in OnListened.
+
+	ALL_CONTEXTS			= 0xFFF00000,
+
+	ALL_SCENTS				= SOUND_CARCASS | SOUND_MEAT | SOUND_GARBAGE,
+
+	ALL_SOUNDS				= 0x000FFFFF & ~ALL_SCENTS,
+};
+
+enum
+{
+	SOUNDLIST_EMPTY = -1
+};
+
+enum NPC_STATE
+{
+	NPC_STATE_INVALID = -1,
+	NPC_STATE_NONE = 0,
+	NPC_STATE_IDLE,
+	NPC_STATE_ALERT,
+	NPC_STATE_COMBAT,
+	NPC_STATE_SCRIPT,
+	NPC_STATE_PLAYDEAD,
+	NPC_STATE_PRONE,				// When in clutches of barnacle
+	NPC_STATE_DEAD
+};

--- a/scripting/srccoop.sp
+++ b/scripting/srccoop.sp
@@ -139,6 +139,10 @@ void LoadGameData()
 	LoadDHookDetour(pGameConfig, hkSetPlayerAvoidState, "CAI_BaseNPC::SetPlayerAvoidState", Hook_SetPlayerAvoidState);
 	#endif
 
+	#if defined ENTPATCH_NPC_SLEEP
+	LoadDHookDetour(pGameConfig, hkBaseNpcUpdateSleepState, "CAI_BaseNPC::UpdateSleepState", Hook_BaseNpcUpdateSleepState);
+	#endif
+
 	#if defined GAMEPATCH_UTIL_GETLOCALPLAYER
 	LoadDHookDetour(pGameConfig, hkUTIL_GetLocalPlayer, "UTIL_GetLocalPlayer", Hook_UTIL_GetLocalPlayer);
 	#endif
@@ -232,12 +236,17 @@ public void OnPluginStart()
 	g_pFeatureMap = new FeatureMap();
 	g_pSpawnOptions.Reset();
 	EquipmentManager.Initialize();
+	DnManager.Initialize();
 	InitializeMenus();
 	
 	g_CoopMapStartFwd = new GlobalForward("SC_OnCoopMapStart", ET_Ignore);
 	g_CoopMapConfigLoadedFwd = new GlobalForward("SC_OnCoopMapConfigLoaded", ET_Ignore, Param_Cell, Param_Cell);
 	g_OnPlayerRagdollCreatedFwd = new GlobalForward("SC_OnPlayerRagdollCreated", ET_Ignore, Param_Cell, Param_Cell);
 	g_OnCoopMapEndFwd = new GlobalForward("SC_OnCoopMapEnd", ET_Event, Param_String, Param_String, Param_Cell);
+	
+	HookUserMessage(GetUserMessageId("TextMsg"), UserMessage_TextMsg, true);
+	HookEvent("player_death", Event_PlayerDeath, EventHookMode_Pre);
+	HookEvent("entity_killed", Event_EntityKilled, EventHookMode_Pre);
 	
 	HookEvent("player_disconnect", Event_PlayerDisconnect);
 	AddNormalSoundHook(PlayerSoundListener);
@@ -246,6 +255,7 @@ public void OnPluginStart()
 	#if defined SRCCOOP_BLACKMESA
 
 	HookEvent("broadcast_teamsound", Event_BroadcastTeamsound, EventHookMode_Pre);
+	HookEvent("broadcast_killstreak", Event_BroadcastKillstreak, EventHookMode_Pre);
 	AddTempEntHook("BlackMesa Shot", BlackMesaFireBulletsTEHook);
 	UserMsg iIntroCredits = GetUserMessageId("IntroCredits");
 	if (iIntroCredits != INVALID_MESSAGE_ID)
@@ -438,6 +448,22 @@ public void OnClientDisconnect_Post(int client)
 	g_szSteamIds[client] = "";
 	g_bPostTeamSelect[client] = false;
 	g_iAddButtons[client] = 0;
+}
+
+public Action UserMessage_TextMsg(UserMsg pMsg, BfRead bf, const int[] pPlayers, int iPlayerCount, bool bReliable, bool bInitialize)
+{
+	return DnManager.TextMsg(bf);
+}
+
+public Action Event_PlayerDeath(Event hEvent, const char[] szName, bool bDontBroadcast)
+{
+	return DnManager.PlayerDeath(hEvent);
+}
+
+public Action Event_EntityKilled(Event hEvent, const char[] szName, bool bDontBroadcast)
+{
+	DnManager.EntityKilled(hEvent);
+	return Plugin_Continue;
 }
 
 public void Event_PlayerDisconnect(Event hEvent, const char[] szName, bool bDontBroadcast)
@@ -813,7 +839,7 @@ public void OnEntityCreated(int iEntIndex, const char[] szClassname)
 			return;
 		}
 		#endif
-		
+
 		// if some explosions turn out to be damaging all players except one, this is the fix
 		// if (strcmp(szClassname, "env_explosion") == 0)
 		// {
@@ -972,8 +998,17 @@ public Action Event_BroadcastTeamsound(Event hEvent, const char[] szName, bool b
 	if (CoopManager.IsCoopModeEnabled())
 	{
 		// block multiplayer announcer
-		hEvent.BroadcastDisabled = true;
-		return Plugin_Changed;
+		return Plugin_Stop;
+	}
+	return Plugin_Continue;
+}
+
+public Action Event_BroadcastKillstreak(Event hEvent, const char[] szName, bool bDontBroadcast)
+{
+	if (CoopManager.IsCoopModeEnabled())
+	{
+		// block multiplayer announcer
+		return Plugin_Stop;
 	}
 	return Plugin_Continue;
 }

--- a/scripting/srccoop.sp
+++ b/scripting/srccoop.sp
@@ -477,6 +477,7 @@ public void Event_PlayerDisconnect(Event hEvent, const char[] szName, bool bDont
 
 public void OnMapEnd()
 {
+	DnManager.Clear();
 	g_pLevelLump.RevertConvars();
 	g_bMapStarted = false;
 }

--- a/translations/srccoop.phrases.txt
+++ b/translations/srccoop.phrases.txt
@@ -199,4 +199,21 @@
 		"ru"			"Состояние игрока успешно очищено."
 	}
 
+	"entity suicided"
+	{
+		"#format"		"{1:s}" // attacker
+		"en"			"{1} suicided!"
+	}
+	
+	"entity killed entity with weapon"
+	{
+		"#format"		"{1:s},{2:s},{3:s}" // attacker, victim, weapon
+		"en"			"{1} killed {2} with {3}!"
+	}
+
+	"entity killed entity"
+	{
+		"#format"		"{1:s},{2:s}" // attacker, victim
+		"en"			"{1} killed {2}!"
+	}
 }


### PR DESCRIPTION
This pull request addresses a problem with AI sleep states and adds native death notices that appear on the HUD. `CAI_BaseNPC::UpdateSleepState` has been fully reconstructed with the singleplayer checks removed so AI should properly be able to sleep. Native death notices are now supported via fake clients.

Fixes #9

![image](https://github.com/ampreeT/SourceCoop/assets/61920833/edac5d1c-50f1-4791-8929-ddbbc756d0ad)

**Changes:**

- Added 1 signature and 3 vtable indexes to gamedata for bms and hl2dm
- Reconstructed `CAI_BaseNPC::UpdateSleepState` without singleplayer checks
- Added native death notices
    - Uses a maximum of 2 fake clients
    - Shows AI kills, AI suicides and player kills on AI