### PR TITLE
`prop_soda` fix

### DIFF
--- a/scripting/srccoop.sp
+++ b/scripting/srccoop.sp
@@ -777,7 +777,7 @@ public void OnEntityCreated(int iEntIndex, const char[] szClassname)
 		
 		// ToDo: support all games
 		#if defined SRCCOOP_BLACKMESA
-		if (strncmp(szClassname, "item_", 5) == 0)
+		if (strncmp(szClassname, "item_", 5) == 0 || strcmp(szClassname, "prop_soda", false) == 0)
 		{
 			if (pEntity.IsPickupItem())
 			{
@@ -924,15 +924,16 @@ public Action Hook_ItemSpawnDelay(int iEntIndex)
 {
 	SDKUnhook(iEntIndex, SDKHook_Spawn, Hook_ItemSpawnDelay);
 	
-	CBaseEntity pEnt = CBaseEntity(iEntIndex);
+	CBaseEntity pEntity = CBaseEntity(iEntIndex);
 	if (g_bMapStarted)
 	{
-		RequestFrame(SpawnPostponedItem, pEnt);
+		RequestFrame(SpawnPostponedItem, pEntity);
 	}
 	else
 	{
-		g_pPostponedSpawns.Push(pEnt);
+		g_pPostponedSpawns.Push(pEntity);
 	}
+
 	return Plugin_Stop;
 }
 
@@ -944,6 +945,7 @@ public void SpawnPostponedItem(CBaseEntity pEntity)
 		g_bIsMultiplayerOverride = false; // IsMultiplayer=false will spawn items with physics
 		pEntity.Spawn();
 		g_bIsMultiplayerOverride = true;
+		pEntity.SetCollisionGroup(COLLISION_GROUP_WEAPON);
 	}
 }
 


### PR DESCRIPTION
`prop_soda` was not passing the pickup item string match which allows for items to be picked up. As a result of this PR fixing that issue, collisions and physics are now enabled for `prop_soda`.

Fixes #102.

![image](https://github.com/ampreeT/SourceCoop/assets/61920833/cf73420d-74b9-4d7e-ae19-cd9ca0726eea)

**Changes:**

- Added `prop_soda` as a pickup object
- Added collision between pickup objects while ignoring debris/players