### PR TITLE
Fixed `CAI_BaseNPC::FindNamedEntity` not catching friends

### DIFF
--- a/scripting/include/srccoop/entitypatch.inc
+++ b/scripting/include/srccoop/entitypatch.inc
@@ -278,10 +278,13 @@ public MRESReturn Hook_FindNamedEntity(int _this, Handle hReturn, Handle hParams
 	{
 		char szName[MAX_CLASSNAME];
 		DHookGetParamString(hParams, 1, szName, sizeof(szName));
-		if ((strcmp(szName, "Player", false) == 0) || (strcmp(szName, "!player", false) == 0))
+		if ((strcmp(szName, "Player", false) == 0)
+			|| (strcmp(szName, "!player", false) == 0)
+			|| (strcmp(szName, "!nearestfriend", false) == 0)
+			|| (strcmp(szName, "!friend", false) == 0))
 		{
 			CBaseEntity pActor = CBaseEntity(DHookGetParam(hParams, 2));
-			if (pActor.IsValid())
+			if (pActor != NULL_CBASEENTITY)
 			{
 				CBasePlayer pBestPlayer = GetNearestPlayer(pActor);
 				if (pBestPlayer != NULL_CBASEENTITY)


### PR DESCRIPTION
Original branch to `!nearestfriend` and `!friend` called `AI_GetSinglePlayer()` which would return `nullptr`.

**Changes:**

- Fixed NPCs not looking at friends (players) during certain random dialogues