### PR TITLE
Black Mesa EDT Chapter 4-5

### DIFF
--- a/edt/bms/bm_c1a0a.edt
+++ b/edt/bms/bm_c1a0a.edt
@@ -31,7 +31,7 @@
 		// HEV checkpoint.
 		"add"
 		{
-			"classname"		"logic_auto"
+			"classname"		"logic_relay"
 			"targetname"	"HEV_checkpoint"
 		}
 		// suit pickup - fire outputs only once
@@ -53,7 +53,7 @@
 				{
 					"output" "OnPlayerPickup"
 					"target" "HEV_checkpoint"
-					"input" "FireUser1"
+					"input" "Trigger"
 					"delay" "0"
 					"timestofire" "1"
 				}
@@ -130,7 +130,7 @@
 			"origin"	"925 4450 415"
 			"angles"	"12.5 -90.0 0.0"
 			"triggerid"	"HEV_checkpoint"
-			"output"	"OnUser1"
+			"output"	"OnTrigger"
 			"bringall"	"1"
 		}
 		"elevatorroom"

--- a/edt/bms/bm_c1a0b.edt
+++ b/edt/bms/bm_c1a0b.edt
@@ -35,9 +35,33 @@
 		{
 			"classname" "logic_auto"
 			"hammerid" "1864584"
+			// remove keyboard animation
+			"outputs"
+			{
+				"remove"
+				{
+					"output"	"OnMapSpawn"
+					"target"	"SCI32_Generator_ss1"
+					"input"		"BeginSequence"
+				}
+			}
 			"functions"
 			{
 				"delay_output" "OnMapSpawn"
+			}
+		}
+		// play keyboard animation immediately
+		"add"
+		{
+			"classname"		"logic_auto"
+			"outputs"
+			{
+				"add"
+				{
+					"output"	"OnMapSpawn"
+					"target"	"SCI32_Generator_ss1"
+					"input"		"BeginSequence"
+				}
 			}
 		}
 		// remove trigger which calls spawn elevator up and closes doors

--- a/edt/bms/bm_c1a1a.edt
+++ b/edt/bms/bm_c1a1a.edt
@@ -18,6 +18,16 @@
 		{
 			"targetname"	"global_newgame_spawner_suit"
 		}
+		// don't know why this is not in the level
+		"add"
+		{
+			"classname"				"env_message"
+			"targetname"			"intro_title_custom"
+			"spawnflags"			"0"
+			"messagevolume"			"10"
+			"messageattenuation"	"0"
+			"message"				"CHAPTER3_TITLE"
+		}
 		"modify"
 		{
 			"classname" "logic_auto"
@@ -28,6 +38,13 @@
 				{
 					"target" "!player"
 					"input" "SetHealth"
+				}
+				"add"
+				{
+					"output"	"OnMapSpawn"
+					"target"	"intro_title_custom"
+					"input"		"ShowMessage"
+					"delay"		"0.75"
 				}
 			}
 		}

--- a/edt/bms/bm_c1a2a.edt
+++ b/edt/bms/bm_c1a2a.edt
@@ -7,13 +7,47 @@
 	"intro_type" "none"
 	"equipment"
 	{
-		"lookup"
-		{
-			"targetname" "items_at_start"
-		}
+		"item"	"item_suit"
+		"item"	"item_weapon_crowbar"
+		"item"	"item_weapon_glock"
+		"item"	"item_ammo_glock"
+		"item"	"item_ammo_glock"
+		"item"	"item_ammo_glock"
+		"item"	"item_battery"
+		"item"	"item_battery"
+		"item"	"item_weapon_frag"
 	}
 	"entity"
 	{
+		// delete world starting equipment
+		"delete"
+		{
+			"targetname" "items_at_start"
+		}
+		// delay backup timer vent explosion to game start
+		"modify"
+		{
+			"classname"		"logic_timer"
+			"targetname"	"backup_timer"
+			"set"
+			{
+				"StartDisabled"	"1"
+			}
+		}
+		"add"
+		{
+			"classname"		"logic_auto"
+			"targetname"	"backup_timer_delay"
+			"outputs"
+			{
+				"add"
+				{
+					"output"	"OnMapSpawn"
+					"target"	"backup_timer"
+					"input"		"Enable"
+				}
+			}
+		}
 		// delay map start
 		"modify"
 		{
@@ -140,6 +174,13 @@
 		{
 			"origin"	"160 -112 16"
 			"angles"	"0 90 0"
+		}
+		"shotgun_pickup"
+		{
+			"origin"	"-2390 -1650 10"
+			"angles"	"5 55 0"
+			"triggerid"	"relay_headcrabscare"
+			"output"	"OnTrigger"
 		}
 	}
 }

--- a/edt/bms/bm_c1a2b.edt
+++ b/edt/bms/bm_c1a2b.edt
@@ -6,13 +6,58 @@
 	"nextmap" "bm_c1a2c"
 	"equipment"
 	{
-		"lookup"
-		{
-			"targetname" "items_at_start"
-		}
+		"item"	"item_suit"
+		"item"	"item_weapon_crowbar"
+		"item"	"item_weapon_glock"
+		"item"	"item_ammo_glock"
+		"item"	"item_ammo_glock"
+		"item"	"item_ammo_glock"
+		"item"	"item_weapon_shotgun"
+		"item"	"item_ammo_shotgun"
+		"item"	"item_ammo_shotgun"
+		"item"	"item_battery"
+		"item"	"item_battery"
+		"item"	"item_weapon_frag"
 	}
 	"entity"
 	{
+		// delete world starting equipment
+		"delete"
+		{
+			"targetname" "items_at_start"
+		}
+		// delay headcrab spawn to the start of the game
+		"modify"
+		{
+			"targetname" "StairwayHeadcrabSpawn"
+			"set"
+			{
+				"StartDisabled" "1"
+			}
+		}
+		"add"
+		{
+			"classname"		"logic_auto"
+			"targetname"	"StairwayHeadcrabSpawn_delay"
+			"outputs"
+			{
+				"add"
+				{
+					"output"	"OnMapSpawn"
+					"target"	"StairwayHeadcrabSpawn"
+					"input"		"Enable"
+				}
+			}
+		}
+		// delay map start
+		"modify"
+		{
+			"classname" "logic_auto"
+			"functions"
+			{
+				"delay_output" "OnMapSpawn"
+			}
+		}
 		// turn prev. changelevel trig into invisible wall
 		"modify"
 		{
@@ -22,15 +67,6 @@
 			{
 				"classname" "func_brush"
 				"rendermode" "10" // dont render
-			}
-		}
-		// hc: dont spawn immediately
-		"modify"
-		{
-			"targetname" "StairwayHeadcrabSpawn"
-			"set"
-			{
-				"StartDisabled" "1"
 			}
 		}
 		// block going past changelevel
@@ -60,153 +96,124 @@
 				}
 			}
 		}
-		// Set up NPC persistance
-		"add"
-		{
-			"classname" "env_global"
-			"targetname" "grd01_following_c1a2b_global"
-			"globalstate" "grd01_following_c1a2b"
-		}
-		"add"
-		{
-			"classname" "env_global"
-			"targetname" "sci04_following_c1a2b_global"
-			"globalstate" "sci04_following_c1a2b"
-		}
-		"add"
-		{
-			"classname" "env_global"
-			"targetname" "grd02_following_c1a2b_global"
-			"globalstate" "grd02_following_c1a2b"
-		}
-		"modify"
-		{
-			"targetname" "GRD02"
-			"outputs"
-			{
-				"add"
-				{
-					"target" "grd02_following_c1a2b_global"
-					"output" "OnDeath"
-					"input"	"TurnOff"
-				}
-			}
-		}
-		"modify"
-		{
-			"targetname" "SCI04"
-			"outputs"
-			{
-				"add"
-				{
-					"target" "sci04_following_c1a2b_global"
-					"output" "OnDeath"
-					"input"	"TurnOff"
-				}
-			}
-		}
-		"modify"
-		{
-			"targetname" "BDetect_Grd01_Storage"
-			"outputs"
-			{
-				"add"
-				{
-					"target" "grd01_following_c1a2b_global"
-					"output" "OnTrigger"
-					"input"	"TurnOn"
-					"timestofire" "1"
-				}
-			}
-		}
-		"modify"
-		{
-			"targetname" "BDetect_Grd02"
-			"outputs"
-			{
-				"add"
-				{
-					"target" "grd02_following_c1a2b_global"
-					"output" "OnTrigger"
-					"input"	"TurnOn"
-					"timestofire" "1"
-				}
-			}
-		}
-		"modify"
-		{
-			"targetname" "BDetect_Sci04"
-			"outputs"
-			{
-				"add"
-				{
-					"target" "sci04_following_c1a2b_global"
-					"output" "OnTrigger"
-					"input"	"TurnOn"
-					"timestofire" "1"
-				}
-			}
-		}
-		// NPC from last map persistance
-		"#if"
-		{
-			"globalstate" "grd01_following_c1a2a"
-			"#then"
-			{
-				"create"
-				{
-					"classname" "npc_human_security"
-					"targetname" "Grd01_Storage"
-					"origin" "-2304 705 45"
-					"additionalequipment" "weapon_glock"
-					"AlwaysTransition" "No"
-					"angles" "0 150.5 0"
-					"CanSpeakWhileScripting" "No"
-					"expressiontype" "2"
-					"GameEndAlly" "No"
-					"physdamagescale" "1.0"
-					"renderamt" "255"
-					"rendercolor" "255 255 255"
-					"spawnflags" "131588"
-					"outputs"
-					{
-						"add"
-						{
-							"target" "grd01_following_c1a2b_global"
-							"output" "OnDeath"
-							"input"	"TurnOff"
-						}
-					}
-				}
-				"create"
-				{
-					"classname" "ai_goal_follow"
-					"targetname" "Grd01_Storage_follow"
-					"actor" "Grd01_Storage"
-					"MaximumState" "1"
-				}
-				"modify"
-				{
-					"hammerid" "2595446"
-					"outputs"
-					{
-						"add"
-						{
-							"target" "Grd01_Storage_follow"
-							"output" "OnTrigger"
-							"input" "Activate"
-						}
-					}
-				}
-			}
-		}
+		//// NPC persistence `GRD02`
+		//"modify"
+		//{
+		//	"targetname" "GRD02"
+		//	"outputs"
+		//	{
+		//		"add"
+		//		{
+		//			"target" "GRD02_transition"
+		//			"output" "OnDeath"
+		//			"input"	"TurnOff"
+		//		}
+		//	}
+		//}
+		//"add"
+		//{
+		//	"classname"		"env_global"
+		//	"targetname"	"GRD02_transition"
+		//	"globalstate"	"GRD02_transition"
+		//	"initialstate"	"1"
+		//	"spawnflags"	"1"
+		//}
+		//// NPC persistence `SCI04`
+		//"modify"
+		//{
+		//	"targetname" "SCI04"
+		//	"outputs"
+		//	{
+		//		"add"
+		//		{
+		//			"target" "SCI04_transition"
+		//			"output" "OnDeath"
+		//			"input"	"TurnOff"
+		//		}
+		//	}
+		//}
+		//"add"
+		//{
+		//	"classname"		"env_global"
+		//	"targetname"	"SCI04_transition"
+		//	"globalstate"	"SCI04_transition"
+		//	"initialstate"	"1"
+		//	"spawnflags"	"1"
+		//}
+		//// NPC persistence `Grd01_Storage`
+		//"#if"
+		//{
+		//	"globalstate" "Grd01_Storage_transition"
+		//	"#then"
+		//	{
+		//		"add"
+		//		{
+		//			"classname"	"logic_auto"
+		//			"functions"
+		//			{
+		//				"delay_output" "OnMapSpawn"
+		//			}
+		//			"outputs"
+		//			{
+		//				"add"
+		//				{
+		//					"output" "OnMapSpawn"
+		//					"target" "Grd01_Storage_follow"
+		//					"input" "Activate"
+		//					"delay" "0"
+		//				}
+		//			}
+		//		}
+		//		"add"
+		//		{
+		//			"classname" "ai_goal_follow"
+		//			"targetname" "Grd01_Storage_follow"
+		//			"actor" "Grd01_Storage"
+		//			"goal"	"!player"
+		//			"MaximumState" "1"
+		//		}
+		//		"add"
+		//		{
+		//			"classname"		"env_global"
+		//			"targetname"	"Grd01_Storage_transition"
+		//			"globalstate"	"Grd01_Storage_transition"
+		//			"initialstate"	"1"
+		//			"spawnflags"	"1"
+		//		}
+		//		"add"
+		//		{
+		//			"classname" "npc_human_security"
+		//			"targetname" "Grd01_Storage"
+		//			"origin" "-2304 705 45"
+		//			"additionalequipment" "weapon_glock"
+		//			"AlwaysTransition" "No"
+		//			"angles" "0 150.5 0"
+		//			"CanSpeakWhileScripting" "No"
+		//			"expressiontype" "2"
+		//			"GameEndAlly" "No"
+		//			"physdamagescale" "1.0"
+		//			"renderamt" "255"
+		//			"rendercolor" "255 255 255"
+		//			"spawnflags" "131588"
+		//			"outputs"
+		//			{
+		//				"add"
+		//				{
+		//					"target" "Grd01_Storage_transition"
+		//					"output" "OnDeath"
+		//					"input"	"TurnOff"
+		//				}
+		//			}
+		//		}
+		//	}
+		//}
 	}
 	"checkpoint"
 	{
 		"spawn"
 		{
-			"origin"	"-2328 457 121"
-			"angles"	"0 267 0"
+			"origin"	"-2280 690 20"
+			"angles"	"-17.5 -107.5 0"
 		}
 	}
 }

--- a/edt/bms/bm_c1a2c.edt
+++ b/edt/bms/bm_c1a2c.edt
@@ -6,13 +6,26 @@
 	"nextmap" "bm_c1a3a"
 	"equipment"
 	{
-		"lookup"
-		{
-			"targetname" "items_at_start"
-		}
+		"item"	"item_suit"
+		"item"	"item_weapon_crowbar"
+		"item"	"item_weapon_glock"
+		"item"	"item_ammo_glock"
+		"item"	"item_ammo_glock"
+		"item"	"item_ammo_glock"
+		"item"	"item_weapon_shotgun"
+		"item"	"item_ammo_shotgun"
+		"item"	"item_ammo_shotgun"
+		"item"	"item_battery"
+		"item"	"item_battery"
+		"item"	"item_weapon_frag"
 	}
 	"entity"
 	{
+		// delete world starting equipment
+		"delete"
+		{
+			"targetname" "items_at_start"
+		}
 		// turn prev. changelevel trig into invisible wall
 		"modify"
 		{

--- a/edt/bms/bm_c1a3a.edt
+++ b/edt/bms/bm_c1a3a.edt
@@ -9,25 +9,29 @@
 
 	"equipment"
 	{
-		"lookup"
-		{
-			"targetname" "/^(suit|weapons|ammo)$/"
-		}
-		#if
-		{
-			// add extra items when returning from c1a3c
-			"globalstate" "c1a3c_c1a3a"
-			#then
-			{
-				"item" "item_weapon_mp5"
-				"item" "item_weapon_mp5"
-				"item" "item_grenade_mp5"
-				"item" "item_weapon_frag"
-			}
-		}
+		"item"	"item_suit"
+		"item"	"item_weapon_crowbar"
+		"item"	"item_weapon_glock"
+		"item"	"item_ammo_glock"
+		"item"	"item_ammo_glock"
+		"item"	"item_ammo_glock"
+		"item"	"item_weapon_shotgun"
+		"item"	"item_ammo_shotgun"
+		"item"	"item_ammo_shotgun"
+		"item"	"item_ammo_shotgun"
+		"item"	"item_battery"
+		"item"	"item_battery"
+		"item"	"item_battery"
+		"item"	"item_weapon_frag"
+		"item"	"item_weapon_frag"
 	}
 	"entity"
 	{
+		// delete world starting equipment
+		"delete"
+		{
+			"targetname" "/^(suit|weapons|ammo)$/"
+		}
 		// delay map start
 		"modify"
 		{
@@ -75,7 +79,7 @@
 		// Part 2
 		// ********************
 		
-		// turn backtracking changelevel trig into invisible wall
+		// turn backtracking changelevel trigger into invisible wall
 		"modify"
 		{
 			"classname" "trigger_changelevel"
@@ -95,11 +99,40 @@
 				"minhealthdmg" "999999"
 			}
 		}
+		// block going past changelevel area
+		"add"
+		{
+			"classname" "func_brush"
+			"rendermode" "10" // dont render
+			"functions"
+			{
+				"copy_model"
+				{
+					"hammerid" "452166"
+				}
+			}
+		}
 		#if
 		{
 			"globalstate" "c1a3c_c1a3a"
 			#then
 			{
+				// delete sentry in the room with the marines
+				"remove"
+				{
+					"classname"		"npc_sentry_ground"
+					"targetname"	"sentry_01"
+				}
+				// remove vent in scientist room
+				"remove"
+				{
+					"targetname"	"OpenSiloDoors_vent"
+				}
+				// remove the coffee cup that the zombie destroys
+				"remove"
+				{
+					"targetname"	"rustyreallyhatesthiscup"
+				}
 				// delete relay on map start, which the map deletes on player spawn, which is too late for us
 				"remove"
 				{
@@ -127,8 +160,8 @@
 				}
 				"gotlunch"
 				{
-					"origin"	"-1536 -1178 -119"
-					"angles"	"0 90 0"
+					"origin"	"-1582 -1286 -119"
+					"angles"	"21 80 0"
 					"triggerid" "bm_c1a3a_headcrab_killer"
 					"output"	"OnTrigger"
 				}

--- a/edt/bms/bm_c1a3b.edt
+++ b/edt/bms/bm_c1a3b.edt
@@ -4,23 +4,90 @@
 {
 	"chapter" "\"We Got Hostiles!\""
 	"nextmap" "bm_c1a3c"
+	"intro_type"	"none"
 	"equipment"
 	{
-		"lookup"
-		{
-			"targetname" "/^(suit|weapons|ammo)$/"
-		}
+		"item"	"item_suit"
+		"item"	"item_weapon_crowbar"
+		"item"	"item_weapon_glock"
+		"item"	"item_ammo_glock"
+		"item"	"item_ammo_glock"
+		"item"	"item_ammo_glock"
+		"item"	"item_weapon_shotgun"
+		"item"	"item_ammo_shotgun"
+		"item"	"item_ammo_shotgun"
+		"item"	"item_ammo_shotgun"
+		"item"	"item_weapon_mp5"
+		"item"	"item_battery"
+		"item"	"item_battery"
+		"item"	"item_battery"
+		"item"	"item_weapon_frag"
+		"item"	"item_weapon_frag"
 	}
 	"entity"
 	{
+		// delete world starting equipment
+		"delete"
+		{
+			"targetname" "/^(suit|weapons|ammo)$/"
+		}
 		// delay map start
 		"modify"
 		{
 			"classname" "logic_auto"
 			"OnMapSpawn" "/^Scene01_DontShootStart/"
+			"outputs"
+			{
+				// stop elevator noises from playing
+				"remove"
+				{
+					"output"	"OnMapSpawn"
+					"target"	"c1a3b_c1a3a_elevator_sound2"
+				}
+				// set delay to `0`.
+				"modify"
+				{
+					"output"	"OnMapSpawn"
+					"target"	"Scene01_DontShoot"
+					"set"
+					{
+						"delay"	"0"
+					}
+				}
+			}
 			"functions"
 			{
 				"delay_output" "OnMapSpawn"
+			}
+		}
+		"modify"
+		{
+			"classname"		"func_tracktrain"
+			"targetname"	"AToBElev"
+			"set"
+			{
+				"target"	"p2"
+			}
+		}
+		"modify"
+		{
+			"classname"		"path_track"
+			"targetname"	"p2"
+			"functions"
+			{
+				"delay_output" "OnPass"
+			}
+		}
+		"modify"
+		{
+			"classname"		"func_button"
+			"targetname"	"eb"
+			"outputs"
+			{
+				"remove"
+				{
+					"output"	"OnPressed"
+				}
 			}
 		}
 		// conveyor sounds
@@ -46,7 +113,8 @@
 			"targetname" "c1a3b-c1a3c-elevator"
 			"set"
 			{
-				"lip" "-580"
+				"lip"			"-580"
+				"forceclosed"	"1"		// prevents the elevator from going down when blocked
 			}
 			"outputs"
 			{
@@ -99,8 +167,9 @@
 	{
 		"spawn"
 		{
-			"origin"	"1862 995 -119"
+			"origin"	"0 0 20"
 			"angles"	"0 270 0"
+			"followid"	"AToBElev"
 		}
 		"bridge"
 		{

--- a/edt/bms/bm_c1a3c.edt
+++ b/edt/bms/bm_c1a3c.edt
@@ -4,15 +4,57 @@
 {
 	"chapter" "\"We Got Hostiles!\""
 	"nextmap" "bm_c1a3a"
+	"intro_type"	"none"
 	"equipment"
 	{
-		"lookup"
-		{
-			"targetname" "/^(suit|weapons|ammo)$/"
-		}
+		"item"	"item_suit"
+		"item"	"item_weapon_crowbar"
+		"item"	"item_weapon_glock"
+		"item"	"item_ammo_glock"
+		"item"	"item_ammo_glock"
+		"item"	"item_ammo_glock"
+		"item"	"item_weapon_shotgun"
+		"item"	"item_ammo_shotgun"
+		"item"	"item_ammo_shotgun"
+		"item"	"item_ammo_shotgun"
+		"item"	"item_weapon_mp5"
+		"item"	"item_battery"
+		"item"	"item_battery"
+		"item"	"item_battery"
+		"item"	"item_weapon_frag"
+		"item"	"item_weapon_frag"
 	}
 	"entity"
 	{
+		// delete world starting equipment
+		"delete"
+		{
+			"targetname" "/^(suit|weapons|ammo)$/"
+		}
+		// open elevator doors at map start
+		"add"
+		{
+			"classname"		"logic_auto"
+			"outputs"
+			{
+				"add"
+				{
+					"output"	"OnMapSpawn"
+					"target"	"c1a3b-c1a3c-elevator_doorleft"
+					"input"		"Open"
+				}
+				"add"
+				{
+					"output"	"OnMapSpawn"
+					"target"	"c1a3b-c1a3c-elevator_doorright"
+					"input"		"Open"
+				}
+			}
+			"functions"
+			{
+				"delay_output" "OnMapSpawn"
+			}
+		}
 		// delay map start
 		"modify"
 		{
@@ -40,6 +82,28 @@
 			"functions"
 			{
 				"delay_output" "OnMapSpawn"
+			}
+		}
+		// set elevator position
+		"modify"
+		{
+			"targetname"	"c1a3b-c1a3c-elevator"
+			"set"
+			{
+				"spawnpos"	"1"
+			}
+		}
+		// disable elevator button
+		"modify"
+		{
+			"classname"		"func_button"
+			"targetname"	"top_button"
+			"outputs"
+			{
+				"remove"
+				{
+					"output"	"OnPressed"
+				}
 			}
 		}
 		// blocker
@@ -93,13 +157,19 @@
 				}
 			}
 		}
+		// remove music fade when reaching far enough into the vents
+		"remove"
+		{
+			"targetname"	"trigger_fade_music"
+		}
 	}
 	"checkpoint"
 	{
 		"spawn"
 		{
-			"origin"	"416 1112 -1351"
-			"angles"	"0 150 0"
+			"origin"	"0 0 20"
+			"angles"	"0 90 0"
+			"followid"	"c1a3b-c1a3c-elevator"
 		}
 		"bunkerairstrike"
 		{


### PR DESCRIPTION
**Changes:**

- `bm_c1a0b`
    - Fixed scientist not playing keyboard animation during wait period
- `bm_c1a1a`
    - Fixed intro title not appearing
- `bm_c1a2a`
    - Fixed vent opening up prematurely while waiting for players to connect
    - Changed player equipment loadout
    - Added checkpoint to shotgun pickup
- `bm_c1a2b`
    - Adjusted security guard shooting headcrab to the start of the map
    - Changed player equipment loadout
    - Adjusted checkpoint positions and angles
- `bm_c1a2c`
    - Changed player equipment loadout
- `bm_c1a3a`
    - Adjusted checkpoint positions and angles
    - Changed player equipment loadout
- `bm_c1a3b`
    - Adjusted initial spawn to inside of the elevator
    - Changed intro type to `none`
    - Fixed changelevel elevator going down when blocked by a player
- `bm_c1a3c`
    - Adjusted initial spawn to inside of the elevator
    - Changed intro type to `none`
    - Fixed music fading out when entering the vents
- `bm_c1a3a`: part 2
    - Removed the sentry in the scripted scene with the marines
    - Removed vent and coffee cup in the scripted scene with the scientist
    - Blocked the end of the level