### PR TITLE
Ignore `mp_timelimit` in cooperative maps

### DIFF
--- a/scripting/include/srccoop/features.inc
+++ b/scripting/include/srccoop/features.inc
@@ -19,6 +19,7 @@ enum SourceCoopFeature
 	FT_KEEP_EQUIPMENT						=	(1 << 13),
 	FT_TRANSFER_PLAYER_STATE				=	(1 << 14),
 	FT_SP_WEAPONS							=	(1 << 15),
+	FT_ENABLE_TIMELIMIT						=	(1 << 16),
 }
 
 methodmap FeatureMap < StringMap
@@ -39,6 +40,7 @@ methodmap FeatureMap < StringMap
 		pMap.SetValue("KEEP_EQUIPMENT", FT_KEEP_EQUIPMENT);
 		pMap.SetValue("TRANSFER_PLAYER_STATE", FT_TRANSFER_PLAYER_STATE);
 		pMap.SetValue("SP_WEAPONS", FT_SP_WEAPONS);
+		pMap.SetValue("ENABLE_TIMELIMIT", FT_ENABLE_TIMELIMIT);
 		
 		return view_as<FeatureMap>(pMap);
 	}

--- a/scripting/include/srccoop/manager.inc
+++ b/scripting/include/srccoop/manager.inc
@@ -186,7 +186,7 @@ methodmap CoopManager
 			CBM_MP_GameRules.SetStateEndTime(STATE_WARMUP, GetGameTime() + iSecondsToWait + 1.0);
 			#endif
 		}
-		else
+		else if (!CoopManager.IsFeatureEnabled(FT_ENABLE_TIMELIMIT))
 		{
 			#if defined SRCCOOP_BLACKMESA
 			CBM_MP_GameRules.SetCurrentState(STATE_ROUND);

--- a/scripting/include/srccoop/manager.inc
+++ b/scripting/include/srccoop/manager.inc
@@ -152,10 +152,6 @@ methodmap CoopManager
 	public static void SetIntroTimeOnHud(const int iSecondsToWait)
 	{
 		bool bShouldShow = iSecondsToWait > -1;
-		
-		#if defined SRCCOOP_BLACKMESA
-		CBM_MP_GameRules.SetStateEndTime(STATE_WARMUP, bShouldShow ? (GetGameTime() + iSecondsToWait + 1.0) : 0.0);
-		#endif
 
 		if (bShouldShow)
 		{
@@ -184,6 +180,18 @@ methodmap CoopManager
 			{
 				EmitSoundToAll(Conf.SND_1, .volume = Conf.SND_TICK_VOL);
 			}
+
+			#if defined SRCCOOP_BLACKMESA
+			CBM_MP_GameRules.SetCurrentState(STATE_WARMUP);
+			CBM_MP_GameRules.SetStateEndTime(STATE_WARMUP, GetGameTime() + iSecondsToWait + 1.0);
+			#endif
+		}
+		else
+		{
+			#if defined SRCCOOP_BLACKMESA
+			CBM_MP_GameRules.SetCurrentState(STATE_ROUND);
+			CBM_MP_GameRules.SetStateEndTime(STATE_ROUND, view_as<float>(INT_MAX));
+			#endif
 		}
 	}
 

--- a/scripts/srccoop-bms-linux-install.sh
+++ b/scripts/srccoop-bms-linux-install.sh
@@ -93,7 +93,6 @@ echo "$map_cycle_txt" > "./Black Mesa Dedicated Server/bms/mapcycle.txt"
 # Create a `server.cfg` with ideal default settings.
 server_cfg=$(cat << EOF
 // SourceCoop settings.
-mp_timelimit 0      // Prevents map switch from round timers.
 mp_fraglimit 0      // Prevents the match from ending when a player has a high enough score.
 mp_teamplay 1       // Enables the scientist team.
 mp_friendlyfire 0   // Disables friendly fire.

--- a/scripts/srccoop-bms-windows-install.ps1
+++ b/scripts/srccoop-bms-windows-install.ps1
@@ -93,7 +93,6 @@ Set-Content -Path "./Black Mesa Dedicated Server/bms/mapcycle.txt" -Value $map_c
 # Create a `server.cfg` with ideal default settings.
 $server_cfg = @'
 // SourceCoop settings.
-mp_timelimit 0      // Prevents map switch from round timers.
 mp_fraglimit 0      // Prevents the match from ending when a player has a high enough score.
 mp_teamplay 1       // Enables the scientist team.
 mp_friendlyfire 0   // Disables friendly fire.


### PR DESCRIPTION
Fixes #230