### PR TITLE
Improved globalstate persistence

### DIFF
--- a/scripting/include/srccoop/manager.inc
+++ b/scripting/include/srccoop/manager.inc
@@ -5,6 +5,13 @@
 // Coop manager
 //------------------------------------------------------
 
+enum MapLoadType
+{
+	MAPLOAD_NEW_GAME,
+	MAPLOAD_SAME_GAME,
+	MAPLOAD_RESTART,
+}
+
 enum struct FireOutputData
 {
 	char m_szName[32];
@@ -32,6 +39,7 @@ enum struct CoopManagerData
 	Handle m_pChangeLevelTimer;
 	int m_iTicksToEnd;
 	CoopConfigLocation m_mapConfigLoc;
+	ArrayList m_hLevelInitGlobalStates;
 }
 
 CoopManagerData g_pCoopManagerData;
@@ -74,12 +82,24 @@ methodmap CoopManager
 	
 		if ((data.m_bIsCoopMap = data.kv != null))
 		{
-			if (CoopManager.IsNewMapSeries())
+			MapLoadType eLoadType = CoopManager.GetMapLoadType();
+			if (eLoadType == MAPLOAD_NEW_GAME)
 			{
-				// reset global states
-				IServerGameDLL.Get().GameShutdown();
+				// reset global states & equipment
+				CGlobalState.Reset();
 				EquipmentManager.ClearAll();
 			}
+			else if (eLoadType == MAPLOAD_RESTART)
+			{
+				// restore global states from last level init
+				if (data.m_hLevelInitGlobalStates != null)
+				{
+					CGlobalState.RestoreFromList(data.m_hLevelInitGlobalStates);
+				}
+			}
+			
+			delete data.m_hLevelInitGlobalStates;
+			data.m_hLevelInitGlobalStates = CGlobalState.SaveToList();
 			g_pLevelLump.ParseMapEntities(szMapEntities);
 			g_pLevelLump.ParseConfigFile(data.kv);
 			g_pLevelLump.ToString(szMapEntities);
@@ -401,20 +421,23 @@ methodmap CoopManager
 		return 1.0 - (1.0 / (iPlayerCount / float(votes))) * g_pConvarEndWaitFactor.FloatValue;
 	}
 
-	public static bool IsNewMapSeries()
+	public static MapLoadType GetMapLoadType()
 	{
-		// Return false if map was changed naturally, true if externally
 		if (GetMapHistorySize() > 0)
 		{
 			char szMap[MAX_MAPNAME], szReason[32]; int startTime;
 			GetMapHistory(0, szMap, sizeof(szMap), szReason, sizeof(szReason), startTime);
 		
-			if (StrEqual(szReason, SC_NORMAL_MAPCHANGE) || StrEqual(szReason, SC_SURVIVAL_RESTART_MAPCHANGE))
+			if (StrEqual(szReason, SC_NORMAL_MAPCHANGE) || StrEqual(szReason, SC_VOTING_SKIP_MAPCHANGE))
 			{
-				return false;
+				return MAPLOAD_SAME_GAME;
+			}
+			else if (StrEqual(szReason, SC_SURVIVAL_RESTART_MAPCHANGE) || StrEqual(szReason, SC_VOTING_RESTART_MAPCHANGE))
+			{
+				return MAPLOAD_RESTART;
 			}
 		}
-		return true;
+		return MAPLOAD_NEW_GAME;
 	}
 	
 	public static void OnMapSeriesFinished()

--- a/scripting/include/srccoop_api/classdef/common/CGlobalState.inc
+++ b/scripting/include/srccoop_api/classdef/common/CGlobalState.inc
@@ -10,6 +10,14 @@ static Handle g_pGlobalEntitySetState;
 static Handle g_pGlobalEntitySetCounter;
 static Handle g_pGlobalEntityAdd;
 
+enum struct globalentity_t
+{
+	char          szName[1024];
+	char          szMap[MAX_MAPNAME];
+	GLOBALESTATE  eState;
+	int           iCounter;
+}
+
 methodmap CGlobalState
 {
 	public static void InitClassdef(const GameData hGameConfig)
@@ -134,6 +142,16 @@ methodmap CGlobalState
 	{
 		return SDKCall(g_pGlobalEntityGetMap, szGlobalMap, iMaxLength, iGlobalIndex);
 	}
+	public static bool GetGlobalEntity(const int iGlobalIndex, globalentity_t pGlobalEntity)
+	{
+		if (CGlobalState.GetName(iGlobalIndex, pGlobalEntity.szName, sizeof(pGlobalEntity.szName)) == -1)
+			return false;
+
+		CGlobalState.GetMap(iGlobalIndex, pGlobalEntity.szMap, sizeof(pGlobalEntity.szMap));
+		pGlobalEntity.eState = CGlobalState.GetStateByIndex(iGlobalIndex);
+		pGlobalEntity.iCounter = CGlobalState.GetCounter(iGlobalIndex);
+		return true;
+	}
 	public static bool SetState(const int iGlobalIndex, const GLOBALESTATE eState)
 	{
 		if (CGlobalState.IsValidIndex(iGlobalIndex))
@@ -180,5 +198,34 @@ methodmap CGlobalState
 	public static int Add(const char[] szGlobalName, const char[] szMapName, const GLOBALESTATE eState)
 	{
 		return SDKCall(g_pGlobalEntityAdd, szGlobalName, szMapName, eState);
+	}
+	public static void Reset()
+	{
+		IServerGameDLL.Get().GameShutdown();
+	}
+
+	public static ArrayList SaveToList()
+	{
+		ArrayList hList = new ArrayList(sizeof(globalentity_t));
+		globalentity_t pGlobalEntity;
+		for (int i = 0; ; i++)
+		{
+			if (!CGlobalState.GetGlobalEntity(i, pGlobalEntity))
+				break;
+			
+			hList.PushArray(pGlobalEntity);
+		}
+		return hList;
+	}
+	public static void RestoreFromList(ArrayList hList)
+	{
+		CGlobalState.Reset();
+		globalentity_t pGlobalEntity;
+		for (int i = 0; i < hList.Length; i++)
+		{
+			hList.GetArray(i, pGlobalEntity);
+			int iGlobalIndex = CGlobalState.Add(pGlobalEntity.szName, pGlobalEntity.szMap, pGlobalEntity.eState);
+			CGlobalState.SetCounter(iGlobalIndex, pGlobalEntity.iCounter);
+		}
 	}
 }


### PR DESCRIPTION
- Survival restart and vote restart will restore saved global states from level init
- Skip intro vote no longer resets globals & equipment
- new enum MapLoadType

External mapchanges such as sm_map, changelevel, /votemap will keep resetting globals & equipment.