### PR TITLE
Fix NPC's not being able to use `weapon_357` #253

### DIFF
--- a/scripting/srccoop.sp
+++ b/scripting/srccoop.sp
@@ -910,14 +910,6 @@ public void OnEntityCreated(int iEntIndex, const char[] szClassname)
 			return;
 		}
 		#endif
-
-		#if defined ENTPATCH_WEAPON_MODELS
-		if (pEntity.IsWeapon())
-		{
-			DHookEntity(hkSetModel, false, iEntIndex, _, Hook_WeaponSetModel);
-			return;
-		}
-		#endif
 		
 		// ToDo: support all games
 		#if defined SRCCOOP_BLACKMESA


### PR DESCRIPTION
Issue was caused by hook returning early before `SetModel` hook was set. When `SP_WEAPONS` is enabled, this issue does not pop up because `weapon_357.dmx` will revert back to the singleplayer world model. Tested on a Linux dedicated server.

Fixes #253