### PR TITLE
Add customizable votemap menu sorting

### DIFF
--- a/configs/srccoop/menu_sorting.txt
+++ b/configs/srccoop/menu_sorting.txt
@@ -2,27 +2,41 @@
 {
 	"PlayerSettings"
 	{
-		"item"		"ToggleThirdperson"
-		"item"		"ToggleDeathCamera"
+		"ToggleThirdperson" {}
+		"ToggleDeathCamera" {}
 	}
 
 	"SoundSettings"
 	{
-		"item"		"ToggleKillsounds"
-		"item"		"ToggleEarBleed"
+		"ToggleKillsounds" {}
+		"ToggleEarBleed" {}
 	}
 
 	"Voting"
 	{
-		"item"		"SurvivalVote"
-		"item"		"MapVote"
-		"item"		"RestartMapVote"
-		"item"		"SkipIntroVote"
+		"SurvivalVote" {}
+		"MapVote"
+		{
+			"Black Mesa Official"
+			{
+				"sorting" "map"
+			}
+			"Workshop maps"
+			{
+				"sorting" "chapter"
+			}
+			"[Unnamed campaigns]"
+			{
+				"sorting" "chapter"
+			}
+		}
+		"RestartMapVote" {}
+		"SkipIntroVote" {}
 	}
 
 	"Other"
 	{
-		"item"		"ToggleKillfeed"
+		"ToggleKillfeed" {}
 	}
 	
 }


### PR DESCRIPTION
Requested by @ak47toh on Discord.

- Makes the order of campaigns and chapters in the map menu customizable.
- Updates menu_sorting.txt to a newer style and adds config options under `MapVote`.
- Specified campaigns are displayed first, in the given order.
- The default chapter sorting is `"map"`,  `"sorting" "chapter"` will additionally sort chapters by name.