### PR TITLE
Fix output delimiter

### DIFF
--- a/scripting/include/srccoop.inc
+++ b/scripting/include/srccoop.inc
@@ -10,7 +10,6 @@
 #if defined SRCCOOP_HL2DM
 	
 	#define CHECK_ENGINE "HL2DM"; if (GetEngineVersion() != Engine_HL2DM)
-	#define OUTPUT_SEPARATOR ","
 	#define INTRO_TIMER_HUDTEXT
 
 	#define ENTPATCH_CUSTOM_NPC_MODELS
@@ -59,7 +58,6 @@
 		#define SRCCOOP_BLACKMESA
 	#endif
 	#define CHECK_ENGINE "Black Mesa"; if (GetEngineVersion() != Engine_BlackMesa)
-	#define OUTPUT_SEPARATOR "\27"
 
 	#define ENTPATCH_CUSTOM_NPC_MODELS
 	#define ENTPATCH_UPDATE_ENEMY_MEMORY

--- a/scripting/include/srccoop/levellump.inc
+++ b/scripting/include/srccoop/levellump.inc
@@ -27,12 +27,20 @@ enum struct CEntityOutputLump
 	float m_flDelay;
 	int m_iTimesToFire;
 	
+	char m_szDelimiter[2];
+	
 	bool LoadFromEntityKeyLump(const CEntityKeyLump pEntityKeyLump)
 	{
 		char buffers[5][MAX_VALUE];
-		if (sizeof(buffers) != ExplodeString(pEntityKeyLump.m_szValue, OUTPUT_SEPARATOR, buffers, sizeof(buffers), sizeof(buffers[])))
+
+		this.m_szDelimiter = "\27"; // 'ESC'
+		if (sizeof(buffers) != ExplodeString(pEntityKeyLump.m_szValue, this.m_szDelimiter, buffers, sizeof(buffers), sizeof(buffers[])))
 		{
-			return false;
+			this.m_szDelimiter = ",";
+			if (sizeof(buffers) != ExplodeString(pEntityKeyLump.m_szValue, this.m_szDelimiter, buffers, sizeof(buffers), sizeof(buffers[])))
+			{
+				return false;
+			}
 		}
 		if (!StringToFloatEx(buffers[3], this.m_flDelay))
 		{
@@ -50,11 +58,14 @@ enum struct CEntityOutputLump
 	
 	void SaveToEntityKeyLump(CEntityKeyLump pEntityKeyLump)
 	{
+		if (this.m_szDelimiter[0] == EOS)
+			this.m_szDelimiter = "\27"; // default to 'ESC'
+		
 		FormatEx(pEntityKeyLump.m_szValue, sizeof(pEntityKeyLump.m_szValue), "%s%s%s%s%s%s%.2f%s%d",
-			this.m_szTargetEntity, OUTPUT_SEPARATOR,
-			this.m_szInputName, OUTPUT_SEPARATOR,
-			this.m_szParameter, OUTPUT_SEPARATOR,
-			this.m_flDelay, OUTPUT_SEPARATOR,
+			this.m_szTargetEntity, this.m_szDelimiter,
+			this.m_szInputName, this.m_szDelimiter,
+			this.m_szParameter, this.m_szDelimiter,
+			this.m_flDelay, this.m_szDelimiter,
 			this.m_iTimesToFire);
 	}
 	


### PR DESCRIPTION
Discovered by ak47toh on Discord.
Custom maps (bm_e17_m2 for example) can use commas for output token delimiters, making entity output modifications fail.
This changes the parser to dynamically adapt.

Reference: https://github.com/ValveSoftware/source-sdk-2013/blob/7191ecc418e28974de8be3a863eebb16b974a7ef/src/game/server/cbase.cpp#L133