### PR TITLE
Fix Nihilanth ForgetEntity crash

### DIFF
--- a/scripting/include/srccoop/playerpatch.inc
+++ b/scripting/include/srccoop/playerpatch.inc
@@ -1087,8 +1087,11 @@ static void ClearNpcMemoryForPlayer(const CBasePlayer pPlayer)
 			pEntity.GetClassname(szClassname, sizeof(szClassname));
 			if (strcmp(szClassname, "npc_abrams") == 0)
 			{
-				// causes a crash in CNPC_Abrams::AimMiniTurret2
-				continue;
+				continue; // causes a crash in CNPC_Abrams::AimMiniTurret2
+			}
+			if (strcmp(szClassname, "npc_nihilanth") == 0)
+			{	
+				continue; // always expects to have an enemy
 			}
 			if (strcmp(szClassname, "npc_human_security") == 0)
 			{


### PR DESCRIPTION
CNPC_Nihilanth::RunTask appears to be calling GetEnemy() and dereferencing the returned null pointer. This enemy was presumably being set to null by us calling the ForgetEntity input.