### PR TITLE
Add fix for players falling out of tram sometimes.

### DIFF
--- a/edt/bms/bm_c0a0a.edt
+++ b/edt/bms/bm_c0a0a.edt
@@ -30,6 +30,11 @@
 			"targetname" "intro_teleport"
 		}
 	}
+	"console"
+	{
+		// enable turbophysics to prevent players from falling out of tram (Fix from Synergy BMS EDTs)
+		"sv_turbophysics" "~L 1"
+	}
 	"checkpoint"
 	{
 		"spawn"

--- a/edt/bms/bm_c0a0b.edt
+++ b/edt/bms/bm_c0a0b.edt
@@ -66,6 +66,11 @@
 			}
 		}
 	}
+	"console"
+	{
+		// enable turbophysics to prevent players from falling out of tram (Fix from Synergy BMS EDTs)
+		"sv_turbophysics" "~L 1"
+	}
 	"checkpoint"
 	{
 		"spawn"

--- a/edt/bms/bm_c0a0c.edt
+++ b/edt/bms/bm_c0a0c.edt
@@ -24,6 +24,11 @@
 			}
 		}
 	}
+	"console"
+	{
+		// enable turbophysics to prevent players from falling out of tram (Fix from Synergy BMS EDTs)
+		"sv_turbophysics" "~L 1"
+	}
 	"checkpoint"
 	{
 		"spawn"


### PR DESCRIPTION
Courtesy of when I was working on BMS for Synergy, which never came about as the BMS team asked us not to do so.