### PR TITLE
Weapon selection prediction glitch fix while carrying object

### DIFF
--- a/scripting/include/srccoop/playerpatch.inc
+++ b/scripting/include/srccoop/playerpatch.inc
@@ -262,9 +262,9 @@ public Action OnPlayerRunCmd(int iClient, int &iButtons, int &iImpulse, float fV
 	#endif
 	
 	#if defined SRCCOOP_BLACKMESA
-	if(iWeapon != 0)
+	if (iWeapon != 0)
 	{
-		if(pPlayer.GetCarriedObject() != NULL_CBASEENTITY)
+		if (pPlayer.GetCarriedObject() != NULL_CBASEENTITY)
 		{
 			pPlayer.ForceDropOfCarriedPhysObjects(); //drop object if carrying one to avoid prediction issues
 		}


### PR DESCRIPTION
Fixes #328 
Black Mesa doesn't hide HUD for weapon slots if the player carrying object. This fix will force drop of  carried object if the player wants to select a weapon.