### PR TITLE
Scientist's syringe fix caused by item instancing

### DIFF
--- a/scripting/srccoop.sp
+++ b/scripting/srccoop.sp
@@ -946,6 +946,10 @@ public void OnEntityCreated(int iEntIndex, const char[] szClassname)
 			{
 				if (CoopManager.IsCoopModeEnabled())
 				{
+					//allow instancing only for map placed syringe to avoid issues with scientist's syringe
+					if (strcmp(szClassname, "item_syringe", false) == 0 && pEntity.GetHammerID() == 0)
+						return;
+					
 					SDKHook(iEntIndex, SDKHook_Spawn, Hook_Item_OnSpawn);
 					
 					#if defined ENTPATCH_BM_BATTERY_DLIGHT

--- a/scripting/srccoop.sp
+++ b/scripting/srccoop.sp
@@ -1102,7 +1102,7 @@ static Action Hook_Item_OnSpawn(int iEntIndex)
 	
 	//allow instancing only for map placed syringe to avoid issues with scientist's syringe
 	if (strcmp(szClassname, "item_syringe", false) == 0 && pItem.GetHammerID() == 0)
-		return;
+		return Plugin_Continue;
 	
 	if (g_bMapStarted)
 	{

--- a/scripting/srccoop.sp
+++ b/scripting/srccoop.sp
@@ -1081,7 +1081,6 @@ public void Hook_EntitySpawnPost(int iEntIndex)
 			{
 				pEntity.edictFlags |= FL_EDICT_ALWAYS;
 			}
-			}
 			#endif
 		}
 		#endif // SRCCOOP_BLACKMESA

--- a/scripting/srccoop.sp
+++ b/scripting/srccoop.sp
@@ -945,11 +945,7 @@ public void OnEntityCreated(int iEntIndex, const char[] szClassname)
 			if (pEntity.IsPickupItem())
 			{
 				if (CoopManager.IsCoopModeEnabled())
-				{
-					//allow instancing only for map placed syringe to avoid issues with scientist's syringe
-					if (strcmp(szClassname, "item_syringe", false) == 0 && pEntity.GetHammerID() == 0)
-						return;
-					
+				{					
 					SDKHook(iEntIndex, SDKHook_Spawn, Hook_Item_OnSpawn);
 					
 					#if defined ENTPATCH_BM_BATTERY_DLIGHT
@@ -1085,6 +1081,7 @@ public void Hook_EntitySpawnPost(int iEntIndex)
 			{
 				pEntity.edictFlags |= FL_EDICT_ALWAYS;
 			}
+			}
 			#endif
 		}
 		#endif // SRCCOOP_BLACKMESA
@@ -1099,7 +1096,15 @@ static Action Hook_Item_OnSpawn(int iEntIndex)
 {
 	SDKUnhook(iEntIndex, SDKHook_Spawn, Hook_Item_OnSpawn);
 	
+	char szClassname[64];
+	GetEntityClassname(iEntIndex, szClassname, sizeof(szClassname));
+	
+	//allow instancing only for map placed syringe to avoid issues with scientist's syringe
+	if (strcmp(szClassname, "item_syringe", false) == 0 && pEntity.GetHammerID() == 0)
+		return;
+		
 	CItem pItem = CItem(iEntIndex);
+	
 	if (g_bMapStarted)
 	{
 		RequestFrame(SpawnPostponedItem, pItem);

--- a/scripting/srccoop.sp
+++ b/scripting/srccoop.sp
@@ -1095,14 +1095,14 @@ static Action Hook_Item_OnSpawn(int iEntIndex)
 {
 	SDKUnhook(iEntIndex, SDKHook_Spawn, Hook_Item_OnSpawn);
 	
+	CItem pItem = CItem(iEntIndex);
+	
 	char szClassname[64];
 	GetEntityClassname(iEntIndex, szClassname, sizeof(szClassname));
 	
 	//allow instancing only for map placed syringe to avoid issues with scientist's syringe
-	if (strcmp(szClassname, "item_syringe", false) == 0 && pEntity.GetHammerID() == 0)
+	if (strcmp(szClassname, "item_syringe", false) == 0 && pItem.GetHammerID() == 0)
 		return;
-		
-	CItem pItem = CItem(iEntIndex);
 	
 	if (g_bMapStarted)
 	{


### PR DESCRIPTION
Fixes #287 
Scientists use anim event to create syringe and attach by AttachTo input. It looks like due to creating new ent instead of orig for instancing the scientist loses syringe ref.
The fix filters if the syringe is placed by level creator or not, so we still can use instancing for map placed syringe but not for syringe created by in game code. If we want to spawn a syringe in our plugins, simply use a hammerid value which is > or < than 0.