### PR TITLE
Removed env_screenoverlay auto delete

### DIFF
--- a/edt/common/base/coop_base_sp_conversion.edt
+++ b/edt/common/base/coop_base_sp_conversion.edt
@@ -256,11 +256,6 @@
 				}
 			}
 		}
-		// env_screenoverlay shows to all players once activated - remove it until a solution is found
-		"delete"
-		{
-			"classname" "env_screenoverlay"
-		}
 		// we never want player_speedmod to suppress HUD in MP as this hides chat and even the main menu
 		"modify"
 		{


### PR DESCRIPTION
Turns out I forget to include this change in the screenoverlay path. This is why SourceCoop servers still don't have env_screenoverlay entities.